### PR TITLE
put confirmation on top instead of bottom

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -20,14 +20,14 @@
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
+  <div><%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "off", 'class' => 'form-control' %></div>
+
   <div><%= f.label :password %><br />
     <%= f.password_field :password, autofocus: "autofocus", autocomplete: "off", 'class' => 'form-control' %></div>
 
   <div><%= f.label :password_confirmation %><br />
     <%= f.password_field :password_confirmation, autocomplete: "off", 'class' => 'form-control' %></div>
-
-  <div><%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "off", 'class' => 'form-control' %></div>
 
   <div style="text-align: center; padding-top: 1em;"><%= f.submit "Update", 'class' => 'button-primary' %></div>
 <% end %>


### PR DESCRIPTION
For consistency with other sites that ask for your old password first, then the new one.

https://app.asana.com/0/11511088400507/24613484709723