### PR TITLE
remove weird cdata tag from SF html email

### DIFF
--- a/lib/salesforce.rb
+++ b/lib/salesforce.rb
@@ -76,7 +76,9 @@ module BeyondZ
     end
 
     def get_welcome_email_html
-      get_email_cache('BZ_New_Signup_Welcome_and_Confirm_Email_Html.html')
+      get_email_cache('BZ_New_Signup_Welcome_and_Confirm_Email_Html.html').
+        sub('<![CDATA[', '').
+        sub(']]>', '')
     end 
 
     def get_welcome_email_text


### PR DESCRIPTION
There's no logical reason I can see for that to be there in the first place.