### PR TITLE
basic confirmation page with salesforce support

### DIFF
--- a/app/views/users/confirm.html.erb
+++ b/app/views/users/confirm.html.erb
@@ -11,7 +11,7 @@
       <section>
         <div class="col-sm-6 col-sm-offset-3 text-center">
           <% if current_user.program_attendance_confirmed %>
-            <p>Thank you for confirming. You are in the final stages of the process.</p>
+            <p>Thank you for confirming your commitment to participate in Beyond Z.</p>
           <% else %>
             <p class="shoutout"><%= current_user.first_name %>, please confirm the following:</p>
           <% end %>
@@ -25,14 +25,14 @@
       <section>
         <div class="col-sm-4 col-sm-offset-4">
           <% if current_user.program_attendance_confirmed %>
-            <p>We will contact you soon with our final decision. Good luck!</p>
+            <p>You'll be hearing from us shortly with more information about our kickoff event.</p>
           <% else %>
             <table><tr>
               <td style="padding-right: 6px; vertical-align: top;">
                 <input id="confirmation" type="checkbox" name="confirmed" />
               </td>
               <td>
-                <label for="confirmation">I will be attending the Beyond Z program at SJSU between October 2014 and May 2015, which includes a minimum of 10 hours a week on average.</label>
+                <label for="confirmation">I confirm that will be attending the Beyond Z program.</label>
               </td>
             </tr></table>
           <% end %>


### PR DESCRIPTION
This revamps an old page to make it part of the new Salesforce flow. Link the users to beyondz.org/users/confirm in the email and this will take it from there, updating their information based on user type.