### PR TITLE
Change account activation message

### DIFF
--- a/app/views/home/welcome.html.erb
+++ b/app/views/home/welcome.html.erb
@@ -20,7 +20,7 @@
                   <%= link_to '<div class="apply-icon"></div><div class="apply-text">Apply now!</div>'.html_safe, new_enrollment_path %><br />
                 </div>
               <% else %>
-                <p class="shoutout">Your account was successfully activated. We will contact you when the application is opened.</p>
+                <p class="shoutout">Your account was successfully activated. We will contact you very soon!</p>
               <% end %>
             <% end %>
 


### PR DESCRIPTION
It's weird to say "we'll contact you when the application is opened" at a time when the application is already open.  So I just made it more generic and the email we send will reflect the current state.