### PR TITLE
Emails sent by the ActionMailer have improper Message-ID format

### DIFF
--- a/app/mailers/acceptance_mailer.rb
+++ b/app/mailers/acceptance_mailer.rb
@@ -1,5 +1,9 @@
+require 'digest/sha2'
 class AcceptanceMailer < ActionMailer::Base
   default from: '"Beyond Z" <no-reply@beyondz.org>'
+
+  # needed because gmail was filtering some messages: http://blog.mailgun.com/tips-tricks-avoiding-gmail-spam-filtering-when-using-ruby-on-rails-action-mailer/
+  default "Message-ID" => ->(v){"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@beyondz.org>"}
 
   def request_availability_confirmation(user)
     @user = user

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,4 +1,8 @@
+require 'digest/sha2'
 class DeviseMailer < Devise::Mailer
+  # needed because gmail was filtering some messages: http://blog.mailgun.com/tips-tricks-avoiding-gmail-spam-filtering-when-using-ruby-on-rails-action-mailer/
+  default "Message-ID" => ->(v){"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@beyondz.org>"}
+
   def confirmation_instructions(record, token, opts = {})
     mail = super
     # your custom logic

--- a/app/mailers/feedback.rb
+++ b/app/mailers/feedback.rb
@@ -1,5 +1,9 @@
+require 'digest/sha2'
 class Feedback < ActionMailer::Base
   default from: 'no-reply@beyondz.org'
+
+  # needed because gmail was filtering some messages: http://blog.mailgun.com/tips-tricks-avoiding-gmail-spam-filtering-when-using-ruby-on-rails-action-mailer/
+  default "Message-ID" => ->(v){"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@beyondz.org>"}
 
   def feedback(from, message)
     @from = from

--- a/app/mailers/reminders.rb
+++ b/app/mailers/reminders.rb
@@ -1,7 +1,11 @@
 # heroku addons:add scheduler
 
+require 'digest/sha2'
 class Reminders < ActionMailer::Base
   default from: 'no-reply@beyondz.org'
+
+  # needed because gmail was filtering some messages: http://blog.mailgun.com/tips-tricks-avoiding-gmail-spam-filtering-when-using-ruby-on-rails-action-mailer/
+  default "Message-ID" => ->(v){"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@beyondz.org>"}
 
   def assignment_nearly_due(to, name, assignment_name, link)
     @name = name

--- a/app/mailers/staff_notifications.rb
+++ b/app/mailers/staff_notifications.rb
@@ -1,5 +1,10 @@
+require 'digest/sha2'
+
 class StaffNotifications < ActionMailer::Base
   default from: '"Website Signup Notifier" <no-reply@beyondz.org>'
+
+  # needed because gmail was filtering some messages: http://blog.mailgun.com/tips-tricks-avoiding-gmail-spam-filtering-when-using-ruby-on-rails-action-mailer/
+  default "Message-ID" => ->(v){"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@beyondz.org>"}
 
   def new_user(new_user)
     @user = new_user

--- a/env.sample
+++ b/env.sample
@@ -90,7 +90,8 @@ SALESFORCE_HOST=test.salesforce.com
 DEFAULT_LEAD_OWNER=<staff email address>
 
 # This must correspond with the magic_token in the salesforce BZ_Settings
-# class. It is a random string of alphanumeric stuff to provide semi-security
+# class. Go to Setup->Develop->Custom Settings->BZ_Settings.
+# It is a random string of alphanumeric stuff to provide semi-security
 # in our communications. It is not real security - it can be intercepted in
 # logs or man-in-the-middle attacks and has all the faults of naked passwords,
 # but it should keep casual url scrapers from setting off our processes.


### PR DESCRIPTION
They may be going to spam.  This fix adds our domain name at the end of the Message-ID as required by Gmail (and the spec?).  See: http://blog.mailgun.com/tips-tricks-avoiding-gmail-spam-filtering-when-using-ruby-on-rails-action-mailer/