### PR TITLE
cross-domain flashes

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -15,6 +15,8 @@
           <br />
           <div><%= f.submit "Resend confirmation instructions", :class => 'button-primary' %></div>
         <% end %>
+        <br />
+        <%= render "devise/shared/links" %>
       </div>
     </section>
   </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -5,13 +5,15 @@
         <h2>Forgot your password?</h2>
 
         <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-          <%= devise_error_messages! %>
+          <%= render :partial => 'shared/form_errors', locals: { object: resource } %>
 
           <div><%= f.label :email %><br />
           <%= f.email_field :email, autofocus: true, :class => 'form-control' %></div>
           <br />
           <div><%= f.submit "Send me reset password instructions", :class => 'button-primary' %></div>
         <% end %>
+        <br />
+        <%= render "devise/shared/links" %>
       </div>
     </section>
   </div>

--- a/app/views/shared/_form_errors.html.erb
+++ b/app/views/shared/_form_errors.html.erb
@@ -1,6 +1,6 @@
   <% if @message != nil || ((defined? object) && object.errors.any?) %>
     <div id="error-explanation">
-      <h2>Please fix the following errors and try again:</h2>
+      <h2>Please check the following and try again:</h2>
       <ul>
         <% if @message != nil %>
           <li><%= @message.html_safe %></li>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -52,8 +52,8 @@ en:
       already_confirmed: "was already confirmed, please try signing in"
       confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
       expired: "has expired, please request a new one"
-      not_found: "not found in our system. Please make sure you are using the same one you used when signing up"
+      not_found: "not found in our system. Please make sure you are using the same one you used when signing up."
       not_locked: "was not locked"
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
-        other: "%{count} errors prohibited this %{resource} from being saved:"
+        one: ""
+        other: ""

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 BeyondzPlatform::Application.routes.draw do
-  devise_for :users, controllers: { confirmations: 'confirmations', sessions: 'sessions' }
+  devise_for :users, controllers: { confirmations: 'confirmations', sessions: 'sessions', passwords: 'passwords' }
 
   root "home#index"
   get '/welcome', to: 'home#welcome'


### PR DESCRIPTION
This makes the password message flash cross domain by putting the cookie on the main beyondz.org domain rather than on the default subdomain only. See the comment in the code as to why this isn't configured. Needs companion RubyCAS PR, though it won't actually hurt anything without it, it also won't work without both sides.