### PR TITLE
slightly better resume validation error messages

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -9,9 +9,13 @@ class Enrollment < ActiveRecord::Base
                            'application/pdf',
                            'application/msword',
                            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-                         ]
+                         ],
+                         message: 'is invalid: please upload either a .doc or a .pdf file'
                        },
-                       size: { in: 0..2.megabytes }
+                       size: {
+                         in: 0..2.megabytes,
+                         message: 'is too large: please upload files no larger than 2 MB'
+                       }
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -14,6 +14,7 @@ class Enrollment < ActiveRecord::Base
                        },
                        size: {
                          in: 0..2.megabytes,
+                         # If you change this size, don't forget to change enrollment/_form.html.erb too so the user sees it there
                          message: 'is too large: please upload files no larger than 2 MB'
                        }
 

--- a/app/views/enrollments/_form.html.erb
+++ b/app/views/enrollments/_form.html.erb
@@ -242,7 +242,7 @@
                 </div>
               </div>
               <div class="form-group coach">
-                <label>Or upload a resume as a .doc or .pdf file</label>
+                <label>Or upload a resume as a .doc or .pdf file (2 MB or less)</label>
                 <%= f.file_field :resume %>
                 <% if @enrollment.resume.present? %>
                   <%= link_to 'Download previously uploaded resume', @enrollment.resume.url %>


### PR DESCRIPTION
This still isn't ideal because Paperclip will show it twice, but it is a lot better than the default. Now it will say:

Resume content type is invalid: please upload either a .doc or a .pdf file
Resume is invalid: please upload either a .doc or a .pdf file

or

Resume size is too large: please upload files no larger than 2 MB


Yes, it can list it twice, annoyingly I don't think I can turn that off without gutting the gem. But still, it reads better than it did.

Also adds a size note right on the form so the user can see it early, before uploading.