### PR TITLE
Fix early signup notification

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -219,7 +219,7 @@ class UsersController < ApplicationController
 
     redirect_to redirect_to_welcome_path(@new_user)
 
-    StaffNotifications.new_user(current_user).deliver
+    StaffNotifications.new_user(@new_user).deliver
   end
 
   private


### PR DESCRIPTION
We notify of signup before confirmation now since we have a hack in place to skip confirmation while we sort out the fact that our confirmation emails go to spam.  This fixes that.