### PR TITLE
Auto-confirm emails on canvas

### DIFF
--- a/lib/lms.rb
+++ b/lib/lms.rb
@@ -28,7 +28,8 @@ module BeyondZ
         'user[terms_of_use]' => true,
         'pseudonym[unique_id]' => user.email,
         'pseudonym[send_confirmation]' => false,
-        'communication_channel[skip_confirmation'] => true,
+        'communication_channel[skip_confirmation]' => true,
+        'communication_channel[confirmation_url]' => true,
         'pseudonym[sis_user_id]' => user_student_id
       )
       response = @canvas_http.request(request)
@@ -43,6 +44,11 @@ module BeyondZ
       raise "Couldn't create user #{user.email} in canvas #{response.body}" if new_canvas_user['id'].nil?
 
       user.canvas_user_id = new_canvas_user['id']
+
+      if new_canvas_user['confirmation_url']
+          request = Net::HTTP::Get.new(new_canvas_user['confirmation_url'])
+          @canvas_http.request(request)
+      end
 
       user
     end


### PR DESCRIPTION
The skip_confirmation sets the channel to active, but not confirmed. This  will automatically confirm it so the user doesn't have to.