### PR TITLE
New volunteer

### DIFF
--- a/app/assets/javascripts/public/enrollments.js
+++ b/app/assets/javascripts/public/enrollments.js
@@ -57,15 +57,24 @@ $(document).ready(function() {
       $('.coach').show();
     if($('#position_student').prop('checked'))
       $('.student').show();
+    if($('#position_volunteer').prop('checked'))
+      $('.volunteer').show();
     
     // Show or hide questions based on user type and program upon selection change:
     $('[value=student]').click(function(){
       $('.coach').fadeOut('fast');
+      $('.volunteer').fadeOut('fast');
       $('.student').fadeIn('fast');
     });
     $('[value=coach]').click(function(){
       $('.student').fadeOut('fast');
+      $('.volunteer').fadeOut('fast');
       $('.coach').fadeIn('fast');
+    });
+    $('[value=volunteer]').click(function(){
+      $('.student').fadeOut('fast');
+      $('.coach').fadeOut('fast');
+      $('.volunteer').fadeIn('fast');
     });
 
     // Hide "other" checkbox/radio detail inputs 

--- a/app/assets/stylesheets/public/enrollments.css.scss
+++ b/app/assets/stylesheets/public/enrollments.css.scss
@@ -74,6 +74,6 @@
   @extend .has-error;
 }
 
-.student, .coach {
+.student, .coach, .volunteer {
   display: none;
 }

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -151,7 +151,7 @@ class EnrollmentsController < ApplicationController
         @program_title = campaign.Program_Title__c
         @program_site = campaign.Program_Site__c
         @request_availability = campaign.Request_Availability__c
-        @meeting_times = campaign.Meeting_Times__c
+        @meeting_times = current_user.applicant_type == 'temp_volunteer' ? campaign.Volunteer_Opportunities__c : campaign.Meeting_Times__c
         @sourcing_options = campaign.Sourcing_Info_Options__c
         # Empty string instead of nil is easier to test for in the view
         # if this isn't filled in, we'll just skip the whole question

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -97,7 +97,7 @@ class EnrollmentsController < ApplicationController
 
     # Set the data from the campaign so we can tie back to it
     @enrollment.campaign_id = campaign.Id
-    @enrollment.position = current_user.applicant_type == 'temp_volunteer' ? 'volunteer' : campaign.Application_Type__c
+    @enrollment.position = campaign.Application_Type__c
 
     # And set on Salesforce that it has been started
     cm.Application_Status__c = 'started'

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -97,7 +97,7 @@ class EnrollmentsController < ApplicationController
 
     # Set the data from the campaign so we can tie back to it
     @enrollment.campaign_id = campaign.Id
-    @enrollment.position = campaign.Application_Type__c
+    @enrollment.position = current_user.applicant_type == 'temp_volunteer' ? 'volunteer' : campaign.Application_Type__c
 
     # And set on Salesforce that it has been started
     cm.Application_Status__c = 'started'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -342,7 +342,7 @@ class UsersController < ApplicationController
 
     if !user[:applicant_type].nil?
       @new_user = User.new(user)
-      unless user[:applicant_type] == 'undergrad_student' || user[:applicant_type] == 'volunteer'
+      unless user[:applicant_type] == 'undergrad_student' || user[:applicant_type] == 'volunteer' || user[:applicant_type] == 'temp_volunteer'
         # Partners, employers, and others are reached out to manually instead of confirming
         # their account. We immediate make on salesforce and don't require confirmation so
         # we can contact them quickly and painlessly (to them!).

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -78,7 +78,7 @@ class UsersController < ApplicationController
       @program_title = campaign.Program_Title__c
       @program_site = campaign.Program_Site__c
       @request_availability = campaign.Request_Availability__c
-      @meeting_times = campaign.Meeting_Times__c
+      @meeting_times = current_user.applicant_type == 'temp_volunteer' ? campaign.Volunteer_Opportunities__c : campaign.Meeting_Times__c
 
       @sf_campaign_id = campaign.Id
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -322,6 +322,8 @@ class User < ActiveRecord::Base
       'Undergrad'
     when 'volunteer'
       'Volunteer'
+    when 'temp_volunteer'
+      'Temp Volunteer'
     when 'employer'
       'Employer'
     when 'partner'

--- a/app/views/admin/users/campaign_mapping.html.erb
+++ b/app/views/admin/users/campaign_mapping.html.erb
@@ -29,6 +29,9 @@
     <tr>
       <td>7011700000056ww</td><td>volunteer</td><td></td><td>San Francisco Bay Area, San Jose</td>
     </tr>
+    <tr>
+      <td>1234567890abcde</td><td>temp_volunteer</td><td></td><td>New Jersey - Rutgets</td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/views/admin/users/campaign_mapping.html.erb
+++ b/app/views/admin/users/campaign_mapping.html.erb
@@ -30,7 +30,7 @@
       <td>7011700000056ww</td><td>volunteer</td><td></td><td>San Francisco Bay Area, San Jose</td>
     </tr>
     <tr>
-      <td>1234567890abcde</td><td>temp_volunteer</td><td></td><td>New Jersey - Rutgets</td>
+      <td>1234567890abcde</td><td>temp_volunteer</td><td></td><td>New Jersey - Rutgers</td>
     </tr>
   </tbody>
 </table>

--- a/app/views/admin/users/import_lead_owner_mapping.html.erb
+++ b/app/views/admin/users/import_lead_owner_mapping.html.erb
@@ -17,6 +17,9 @@
       <td>brian@bebraven.org</td><td>volunteer</td><td></td><td>San Francisco Bay Area, East Bay</td>
     </tr>
     <tr>
+      <td>brian@bebraven.org</td><td>temp_volunteer</td><td></td><td>San Francisco Bay Area, East Bay</td>
+    </tr>
+    <tr>
       <td>brian@bebraven.org</td><td>undergrad_student</td><td>City College of New York</td><td></td>
     </tr>
     <tr>

--- a/app/views/enrollments/_form.html.erb
+++ b/app/views/enrollments/_form.html.erb
@@ -13,7 +13,7 @@
           <h1>Application for <%= @program_title %> - <%= @program_site %><br /><%= Date.today.year %></h1>
           </header>
 
-          <p class="help coach">
+          <p class="help coach volunteer">
            To apply to volunteer as a <%= @program_title %> Leadership Coach in our <%= @program_site %> program, please complete and submit this application in its entirety. Your answers will be automatically saved as you move between questions, and you can safely leave this page and log back in at any time to resume your work. Your application won't be considered for evaluation until you click SEND at the bottom of the form.
           </p>
 
@@ -29,7 +29,7 @@
         </div>
         <!--.section-container--> 
       </div>
-      <div class="plank knockout-md coach student">
+      <div class="plank knockout-md coach student volunteer">
         <div class="section-container">
           <ul id="jumplinks" style="padding: 20px 0;"></ul>
         </div>
@@ -38,18 +38,20 @@
         <div class="section-container">
           <section>
             <div id="form-basics">
-              <h2 class=" coach student form-section-header">Basic Information</h2>
+              <h2 class=" coach volunteer student form-section-header">Basic Information</h2>
 
               <!-- I'm keeping this here because the javascript checks these IDs
                    but eventually we should probably remove it and do it all server side. -->
               <div class="form-group" id="form-user-type" <%= (@position_is_set ? 'style="display: none;"'.html_safe : '') %>>
                 <h5>Applying as</h5>
                 <input value="" type="hidden" name="position" />
-                <label class="radio"><%= f.radio_button :position, 'coach', 'value' => 'coach', 'id' => 'position_coach' %>Leadership Coach</label><label class="radio"><%= f.radio_button :position, 'student', 'value' => 'student', 'id' => 'position_student' %>Participant (student)</label>
+                <label class="radio"><%= f.radio_button :position, 'coach', 'value' => 'coach', 'id' => 'position_coach' %>Leadership Coach</label>
+                <label class="radio"><%= f.radio_button :position, 'student', 'value' => 'student', 'id' => 'position_student' %>Participant (student)</label>
+                <label class="radio"><%= f.radio_button :position, 'volunteer', 'value' => 'volunteer', 'id' => 'position_volunteer' %>Volunteer</label>
               </div>
               <!-- end part that should be cut -->
 
-              <div class="coach student" id="form-name">
+              <div class="coach volunteer student" id="form-name">
                 <h4>Your Name</h4>
                 <div class="form-group has-success">
                   <%= f.label :first_name %>
@@ -65,7 +67,7 @@
                 </div>
               </div>
               <!-- #form-name -->
-              <div class="coach student" id="form-contact">
+              <div class="volunteer coach student" id="form-contact">
                 <h4>Your Contact Info</h4>
                 <div class="form-group has-success">
                   <label>Primary Email</label>
@@ -106,11 +108,11 @@
         </div>
         <!-- .section-container --></div>
 
-      <div class="plank plain-lt both coach student">
+      <div class="plank plain-lt both volunteer coach student">
         <div class="section-container">
           <section>
             <div id="form-academics">
-              <h2 class="coach student form-section-header">Academic Background</h2>
+              <h2 class="volunteer coach student form-section-header">Academic Background</h2>
               <div style="margin-bottom: 2.5em;">
                 <!-- I'm not using the checkbox directly because we can't
                      distinguish between explicitly unchecked and initial
@@ -133,7 +135,7 @@
                 </div>
                 <div class="form-group both">
                   <label class="student">Year of expected graduation</label>
-                  <label class="coach">Year of graduation</label>
+                  <label class="volunteer coach">Year of graduation</label>
                   <%= f.text_field :undergraduate_year, 'class' => 'form-control short', 'step' => '1', 'type' => 'number', 'min' => Date.today.year - 50 %>
                   <!-- the -50 there is an arbitrary amount to account for the coach case,
                        where they may have graduated many years ago, -->
@@ -146,8 +148,8 @@
 
                 <p class="help student">Note: We are asking the following questions in order to gain a fuller understanding of your academic background. Your answers will not directly affect your chances of being accepted.</p>
 
-                <div class="form-group both coach student">
-                  <label>Major<span class="student">/Concentration or intended major, if you have one. (Leave blank if none. If pursuing multiple majors, list all.)</span> <span class="coach"> (List all, if multiple)</span></label>
+                <div class="form-group both volunteer coach student">
+                  <label>Major<span class="student">/Concentration or intended major, if you have one. (Leave blank if none. If pursuing multiple majors, list all.)</span> <span class="volunteer coach"> (List all, if multiple)</span></label>
                   <%= f.text_field :major, 'class' => 'form-control', 'type' => 'text', :maxlength => '115' %>
                 </div>
 
@@ -161,7 +163,7 @@
                 </div>
 
 
-                <div class="form-group coach">
+                <div class="form-group volunteer coach">
                   <label>Graduate school, if any</label>
                   <%= f.text_field :grad_school, 'class' => 'form-control', 'type' => 'text', 'maxlength' => '45' %>
                   <label>Graduate degree</label>
@@ -180,13 +182,13 @@
         <!-- .section-container --></div>
 
 
-      <div class="plank plain-md coach student">
+      <div class="plank plain-md volunteer coach student">
         <div class="section-container">
           <section>
             <div id="form-prof-bkg">
               <h2 class="student">Professional and Volunteer Background and Commitment</h2>
-              <h2 class="coach">Professional and Volunteer Experience</h2>
-              <div class="form-group coach">
+              <h2 class="volunteer coach">Professional and Volunteer Experience</h2>
+              <div class="form-group volunteer coach">
                 <h5>What is your current occupation?:</h5>
                 <p class="help">Please respond to at least one of the following questions about your occupation (industry, company, title).</p>
                 <label>Industry:</label>
@@ -196,11 +198,11 @@
                 <label>Title:</label>
                   <%= f.text_field :title, "class"=>'form-control', 'maxlength' => '75' %><br />
               </div>
-              <div class="form-group coach student">
+              <div class="form-group volunteer coach student">
                 <label class="student">Please list all your extracurricular, volunteer, and professional commitments for the upcoming school year (<%= Date.today.year %> - <%= Date.today.year+1 %>).</label>
-                <label class="coach">Please list any other significant volunteer commitments you've made for the upcoming year (<%= Date.today.year %> - <%= Date.today.year+1 %>), including Board commitments, pro bono work, coaching, and other volunteer roles (recurring or occasional).</label>
+                <label class="volunteer coach">Please list any other significant volunteer commitments you've made for the upcoming year (<%= Date.today.year %> - <%= Date.today.year+1 %>), including Board commitments, pro bono work, coaching, and other volunteer roles (recurring or occasional).</label>
                 <p class="help student">Please include approximate hours per month, and if it varies by semester, please note that too. Ex: Student worker at the library, 25 hours/month. Rugby captain, 30 hours/month, fall semester only.</p>
-                <p class="help coach">Please include approximate hours per month, and if it varies by season, please note that too. Ex: AAU girls' coach, 10 hours/week, summer only. Board member, Carver Academy - East, 4 hours/month.</p>
+                <p class="help volunteer coach">Please include approximate hours per month, and if it varies by season, please note that too. Ex: AAU girls' coach, 10 hours/week, summer only. Board member, Carver Academy - East, 4 hours/month.</p>
                 <%= f.text_area :other_commitments, 'class' => 'form-control', 'maxlength' => '1000' %>
               </div>
 
@@ -212,16 +214,18 @@
                 <%= f.text_area :meaningful_activity, 'class' => 'form-control', 'maxlength' => '1000' %>
               </div>
 
-              <div class="form-group coach student">
-                <label class="coach">Please provide a link to a "digital fingerprint" that will help us understand you better.</label>
-                <p class="help coach">Good examples include: your LinkedIn profile, an article you wrote, the website of an organization particularly meaningful to you, etc. (Less helpful are links to your Facebook, Instagram, or Twitter accounts.) Please make sure the links are public.<span class="coach"> If you'd prefer to upload a document in lieu of submitting a second link, please click the "Choose File" button below.</span></p>
-                <div class="input-group coach">
+              <div class="form-group volunteer coach student">
+                <label class="volunteer coach">Please provide a link to a "digital fingerprint" that will help us understand you better.</label>
+                <p class="help volunteer coach">Good examples include: your LinkedIn profile, an article you wrote, the website of an organization particularly meaningful to you, etc. (Less helpful are links to your Facebook, Instagram, or Twitter accounts.) Please make sure the links are public.<span class="volunteer coach"> If you'd prefer to upload a document in lieu of submitting a second link, please click the "Choose File" button below.</span></p>
+                <div class="input-group volunteer coach">
                   <%= f.text_field :digital_footprint, 'class' => 'form-control medium', 'type' => 'url', 'placeholder' => 'Paste URL here', 'onblur' => 'this.value = this.value.replace(/[^a-zA-Z0-9%\-_\.~:\/\?#\[\]@!\$\'\(\)\*\&\+,;=]/g, ""); if(this.value.length && this.value.indexOf("http") != 0) this.value = "http://"+this.value;' %>
+                </div>
+                <div class="input-group coach">
                   <%= f.text_field :digital_footprint2, 'class' => 'form-control medium', 'type' => 'url', 'placeholder' => 'Paste URL here', 'onblur' => 'this.value = this.value.replace(/[^a-zA-Z0-9%\-_\.~:\/\?#\[\]@!\$\'\(\)\*\&\+,;=]/g, ""); if(this.value.length && this.value.indexOf("http") != 0) this.value = "http://"+this.value;' %>
                 </div>
               </div>
-              <div class="form-group coach student" style="clear: left;">
-                <label class="coach">Or upload a resume as a .doc or .pdf file (2 MB or less)</label>
+              <div class="form-group volunteer coach student" style="clear: left;">
+                <label class="volunteer coach">Or upload a resume as a .doc or .pdf file (2 MB or less)</label>
                 <label class="student">Optionally, you may upload a resume as a .doc or .pdf file (2 MB or less)</label>
                 <%= f.file_field :resume %>
                 <% if @enrollment.resume.present? %>
@@ -230,7 +234,7 @@
               </div>
               <!-- #form-resume -->
              <div class="form-group student">
-                <label class="coach">If still in college, what do you hope to do post-graduation?</label>
+                <label class="volunteer coach">If still in college, what do you hope to do post-graduation?</label>
                 <label class="student">If you had to choose now, what job/profession do you want to pursue after graduation?</label>
                 <p class="help">Even if you aren't quite sure yet, please let us know what you are hoping to do, or options you are seriously considering.</p>
                 <%= f.text_area :post_graduation_plans, 'class' => 'form-control', 'maxlength' => '150' %>
@@ -243,16 +247,17 @@
       </div>
 
 
-      <div class="plank plain-lt both coach student">
+      <div class="plank plain-lt both volunteer coach student">
         <div class="section-container">
           <section>
             <div id="form-reflective">
-              <h2 class="coach student form-section-header">Short-Answer Reflective Questions</h2>
+              <h2 class="volunteer coach student form-section-header">Short-Answer Reflective Questions</h2>
               <p class="help">Please use complete sentences!</p>
 
-              <div class="form-group coach student">
+              <div class="form-group volunteer coach student">
                 <label class="student">Why do you want to join the <%= @program_title %>?</label>
                 <label class="coach">Why do you want to be a <%= @program_title %> Leadership Coach?</label>
+                <label class="volunteer">Why do you want to be a <%= @program_title %> volunteer and what areas of personal expertise or passion are you excited to share?</label>
                 <%= f.text_area :why_bz, 'class' => 'form-control', 'maxlength' => '500' %>
               </div>
 
@@ -278,12 +283,12 @@
         </div>
       </div>
 
-      <div class="plank plain-md student coach">
+      <div class="plank plain-md student volunteer coach">
         <div class="section-container">
           <section>
-            <div id="form-references" class="coach">
-              <h2 class="coach">References</h2>
-              <p class="help">Please list TWO people we could contact as character references. Good examples include a manager, colleague, professor, mentor, or a peer who knows you well.</p>
+            <div id="form-references" class="volunteer coach">
+              <h2 class="volunteer coach">References</h2>
+              <p class="help">Please list <span class="coach">TWO people we could contact as character references</span><span class="volunteer">a person we could contact as a character reference</span>. Good examples include a manager, colleague, professor, mentor, or a peer who knows you well.</p>
               <p>For each reference, please provide either a phone number or email address (or both).</p>
               <div>
                                 <div class="form-refernce">
@@ -310,7 +315,7 @@
                   </div>
                 </div>
                 <!-- .form-reference -->
-                                <div class="form-refernce">
+                                <div class="form-refernce coach student">
                   <div class="form-group">
                     <label>Reference 2 Name</label>
                     <%= f.text_field :reference2_name, 'class' => 'form-control medium', 'type' => 'text', 'placeholder' => 'First and last name', 'maxlength' => 240 %>
@@ -342,11 +347,11 @@
         <!-- .section-container --> 
       </div>
 
-      <div class="plank plain-lt both coach student">
+      <div class="plank plain-lt both volunteer coach student">
         <div class="section-container">
           <section>
             <div id="form-personal-bkg">
-              <h2 class="coach student">Personal Background</h2>
+              <h2 class="volunteer coach student">Personal Background</h2>
               <p class="help">We strive to ensure our community is diverse. Please respond to the following questions about your background, identity and experiences to the extent you feel comfortable.<br />
               All questions in this section are <b>optional</b> and have no bearing on our selection decisions.</p>
               <h5>Which race(s)/ethnicity(-ies) do you identify with (check all that apply) <sup>&dagger;</sup> :</h5>
@@ -409,11 +414,11 @@
         <!-- .section-container --></div>
 
 
-      <div class="plank plain-lt both coach <%= (@request_availability && @meeting_times) ? "student" : "" %>">
+      <div class="plank plain-lt both volunteer coach <%= (@request_availability && @meeting_times) ? "student" : "" %>">
         <div class="section-container">
           <section>
             <div id="form-availability">
-              <h2 class="coach <%= (@request_availability && @meeting_times) ? "student" : "" %>">Availability</h2>
+              <h2 class="volunteer coach <%= (@request_availability && @meeting_times) ? "student" : "" %>">Availability</h2>
 
               <% if @request_availability && @meeting_times %>
               <input type="hidden" name="meeting_times_required" value="1" />
@@ -423,10 +428,13 @@
               <p class="student"><i>Please be accurate:</i> You will be assigned to a group that meets weekly during one of these meeting times. Note: It's important that you are as accurate as possible in this application, though we also understand your schedule may change after you’ve submitted. You'll have another chance to confirm your availability before program launch.</p>
 
               <%= f.label :meeting_times, "Please select from the list below ALL <u>times</u> during which you expect to be available to lead cohort sessions through the end of #{Date.today.year}.".html_safe, :class => 'coach' %>
+              <%= f.label :meeting_times, "Please select from the list below ALL <u>times</u> during which you expect to be available to volunteer..".html_safe, :class => 'volunteer' %>
 
-              <p class="coach"><i>Please be flexible:</i> The more options you select, the greater our opportunity to ensure all participants benefit from the great diversity of our community.</p>
+              <p class="volunteer coach"><i>Please be flexible:</i> The more options you select, the greater our opportunity to ensure all participants benefit from the great diversity of our community.</p>
 
-              <p class="coach"><i>Please note</i>: Your invitation to join <%= @program_title %> - <%= @program_site %> will include a specific campus location, day, and timeslot, at which point you'll be asked to officially confirm your role. It's important that you are as accurate as possible, so we can make reliable matches between coaches and participants. However, we also understand your schedule may change after you've submitted. <i>If that happens, or if you are currently very unsure of your fall schedule, please email us with details at <a href="mailto:info@bebraven.org">info@bebraven.org</a>.</i></p>
+              <p class="coach"><i>Please note</i>: Your invitation to join <%= @program_title %> - <%= @program_site %> will include a specific campus location, day, and timeslot, at which point you'll be asked to officially confirm your role. It's important that you are as accurate as possible, so we can make reliable matches between coaches and participants. However, we also understand your schedule may change after you've submitted. <i>If that happens, or if you are currently very unsure of your upcoming schedule, please email us with details at <a href="mailto:info@bebraven.org">info@bebraven.org</a>.</i></p>
+
+              <p class="volunteer"><i>Please note</i>: Your invitation to join <%= @program_title %> - <%= @program_site %> will include a specific campus location, day, and timeslot, at which point you'll be asked to officially confirm your participation. However, we also understand your schedule may change after you've submitted. <i>If that happens, or if you are currently very unsure of your upcoming schedule, please email us with details at <a href="mailto:info@bebraven.org">info@bebraven.org</a>.</i></p>
 
               <p>You must check at least one option.</p>
 
@@ -448,17 +456,21 @@
               <br />
 
               <% end %>
-              <h5 class="coach">Please affirm your commitment:</h5>
-              <div class="form-group coach" id="coach-affirm-holder">
-                <label class="checkbox">
+              <h5 class="volunteer coach">Please affirm your commitment:</h5>
+              <div class="form-group volunteer coach" id="coach-affirm-holder">
+                <label class="checkbox coach">
                   <%= f.check_box :affirm_commit_coach %>
                   <span class="bs-wrapper"><span class="control-label"> I affirm that to the best of my knowledge I can fulfill the commitment to participate in all Leadership Coach activities, which can include: facilitating weekly cohort sessions (a mix of in-person and virtual); leading virtual individual coaching sessions participants; and delivering feedback on selected artifacts (e.g., resumes) submitted by participants.</span></span>
                 </label>
 
+                <label class="checkbox volunteer">
+                  <%= f.check_box :affirm_commit_coach %>
+                  <span class="bs-wrapper"><span class="control-label"> I affirm that to the best of my knowledge I can fulfill the commitment to participate in one or more of the selected activities above.</span></span>
+                </label>
               </div>
 
-              <div class="form-group coach">
-                <span class="coach">Please let us know of any dates that you anticipate you will not be available through the end of <%= Date.today.year %>.</span>
+              <div class="form-group volunteer coach">
+                <span class="volunteer coach">Please let us know of any dates that you anticipate you will not be available through the end of <%= Date.today.year %>.</span>
                 <%= f.text_area :cannot_attend, 'class' => 'form-control', 'maxlength' => '500', 'style'=>'height: 6em !important;' %>
               </div>
             </div>
@@ -497,11 +509,11 @@
       </div>
 
 
-      <div class="plank plain-md coach student">
+      <div class="plank plain-md volunteer coach student">
         <div class="section-container">
           <section>
             <div id="form-almost-done">
-              <h2 class="coach student">Almost Done</h2>
+              <h2 class="volunteer coach student">Almost Done</h2>
               <div class="form-group">
                 <label>Anything else you'd like to share?</label>
                 <p class="help">Please let us know any additional information you wish to share about your interest in <%= @program_title %> - <%= @program_site %>.</p>
@@ -541,7 +553,7 @@
           </section>
         </div>
       </div>
-      <div class="plank tertiary-md student coach">
+      <div class="plank tertiary-md student volunteer coach">
         <div class="section-container">
           <section>
             <div id="form-end">

--- a/app/views/enrollments/_form.html.erb
+++ b/app/views/enrollments/_form.html.erb
@@ -428,7 +428,7 @@
               <p class="student"><i>Please be accurate:</i> You will be assigned to a group that meets weekly during one of these meeting times. Note: It's important that you are as accurate as possible in this application, though we also understand your schedule may change after you’ve submitted. You'll have another chance to confirm your availability before program launch.</p>
 
               <%= f.label :meeting_times, "Please select from the list below ALL <u>times</u> during which you expect to be available to lead cohort sessions through the end of #{Date.today.year}.".html_safe, :class => 'coach' %>
-              <%= f.label :meeting_times, "Please select from the list of one-time volunteer opportunities for Spring 2016 below. (You may select as many as you would like)".html_safe, :class => 'volunteer' %>
+              <%= f.label :meeting_times, "Please select from the list of one-time volunteer opportunities below. (You may select as many as you would like)".html_safe, :class => 'volunteer' %>
 
               <p class="coach"><i>Please be flexible:</i> The more options you select, the greater our opportunity to ensure all participants benefit from the great diversity of our community.</p>
 

--- a/app/views/enrollments/_form.html.erb
+++ b/app/views/enrollments/_form.html.erb
@@ -289,7 +289,7 @@
             <div id="form-references" class="volunteer coach">
               <h2 class="volunteer coach">References</h2>
               <p class="help">Please list <span class="coach">TWO people we could contact as character references</span><span class="volunteer">a person we could contact as a character reference</span>. Good examples include a manager, colleague, professor, mentor, or a peer who knows you well.</p>
-              <p>For each reference, please provide either a phone number or email address (or both).</p>
+              <p><span class="coach student">For each reference, p</span><span class="volunteer">P</span>lease provide either a phone number or email address (or both).</p>
               <div>
                                 <div class="form-refernce">
                   <div class="form-group">
@@ -383,7 +383,7 @@
                   <%= f.check_box :identify_first_gen %>
                   I identify as a first-generation college student <span class="help"><br />(i.e., I don't have a parent or legal guardian who has completed a four-year degree)</span></label>
 
-                <label class="checkbox">
+                <label class="checkbox coach student">
                   <%= f.check_box :study_abroad %>
                   I am an international student studying abroad in the United States for only one semester.</label>
               </div>
@@ -428,9 +428,9 @@
               <p class="student"><i>Please be accurate:</i> You will be assigned to a group that meets weekly during one of these meeting times. Note: It's important that you are as accurate as possible in this application, though we also understand your schedule may change after you’ve submitted. You'll have another chance to confirm your availability before program launch.</p>
 
               <%= f.label :meeting_times, "Please select from the list below ALL <u>times</u> during which you expect to be available to lead cohort sessions through the end of #{Date.today.year}.".html_safe, :class => 'coach' %>
-              <%= f.label :meeting_times, "Please select from the list below ALL <u>times</u> during which you expect to be available to volunteer..".html_safe, :class => 'volunteer' %>
+              <%= f.label :meeting_times, "Please select from the list of one-time volunteer opportunities for Spring 2016 below. (You may select as many as you would like)".html_safe, :class => 'volunteer' %>
 
-              <p class="volunteer coach"><i>Please be flexible:</i> The more options you select, the greater our opportunity to ensure all participants benefit from the great diversity of our community.</p>
+              <p class="coach"><i>Please be flexible:</i> The more options you select, the greater our opportunity to ensure all participants benefit from the great diversity of our community.</p>
 
               <p class="coach"><i>Please note</i>: Your invitation to join <%= @program_title %> - <%= @program_site %> will include a specific campus location, day, and timeslot, at which point you'll be asked to officially confirm your role. It's important that you are as accurate as possible, so we can make reliable matches between coaches and participants. However, we also understand your schedule may change after you've submitted. <i>If that happens, or if you are currently very unsure of your upcoming schedule, please email us with details at <a href="mailto:info@bebraven.org">info@bebraven.org</a>.</i></p>
 

--- a/app/views/home/welcome.html.erb
+++ b/app/views/home/welcome.html.erb
@@ -7,7 +7,7 @@
           <p class="shoutout">Check your email at <br /> <%= @new_user.email %> <br /> to complete your sign-up.</p></p>
           <p class="feature"><strong>Tip:</strong> if you don't see it in your inbox within a few minutes, please check your spam folder.</p>
         <% elsif @new_user %>
-          <% if @new_user.applicant_type == 'volunteer' || @new_user.applicant_type == 'undergrad_student' %>
+          <% if @new_user.applicant_type == 'volunteer' || @new_user.applicant_type == 'undergrad_student' || @new_user.applicant_type == 'temp_volunteer' %>
             <!-- We should be able to re-enable apply now in Salesforce, overriding applicatio_received. The second clause here allows that. -->
             <% if @application_received && !(@new_user.apply_now_enabled || !Rails.application.secrets.salesforce_username) %>
               <h2>Thank you for applying to <%= @program_title %>.</h2>

--- a/app/views/staff_notifications/new_user.text.erb
+++ b/app/views/staff_notifications/new_user.text.erb
@@ -13,6 +13,8 @@ First name: <%= @user.first_name %>
       %> Grad student: <%= @user.university_name %>, anticipated graduation in <%= @user.anticipated_graduation %><%
     when 'undergrad_student'
       %> Undergrad student: <%= @user.university_name %>, anticipated graduation in <%= @user.anticipated_graduation %><%
+    when 'temp_volunteer'
+      %> Temp volunteer: <%= @user.applicant_details %><%
     when 'school_student'
       %> Student: <%= @user.anticipated_graduation %><%
     end %>

--- a/app/views/users/_temp_volunteer.html.erb
+++ b/app/views/users/_temp_volunteer.html.erb
@@ -1,0 +1,42 @@
+<div class="form-option-details">
+  <% unless @hide_other_regions %>
+  <section>
+    <div>
+      <span class="required">I can help in:</span>
+      <br />
+      <%= render :partial => 'areas', :locals => { :f => f } %>
+    </div>
+  </section>
+  <% else %>
+    <%= f.hidden_field :bz_region, :value => params[:user][:bz_region] %>
+  <% end %>
+
+
+  <section>
+    <div>
+      Profession / job title:
+    </div>
+    <div class="col-sm-7">
+      <%= f.text_field :profession, :class => 'form-control', :maxlength => '70' %>
+    </div>
+  </section>
+  <section>
+    <div>
+      Company:
+    </div>
+    <div class="col-sm-7">
+      <%= f.text_field :company, :class => 'form-control', :maxlength => '70' %>
+    </div>
+  </section>
+
+  <section>
+    <div class="required">
+      Please create a password to protect any personal information you may provide us.
+    </div>
+    <div class="col-sm-7">
+      <%= f.password_field :password, :class => 'form-control', placeholder: 'Create a password', pattern: '.{4,}', title: 'make a password at least four characters long', :required => 'required' %>
+    </div>
+  </section>
+
+</div>
+

--- a/app/views/users/confirm.html.erb
+++ b/app/views/users/confirm.html.erb
@@ -14,6 +14,8 @@
             <p class="shoutout">Welcome to the <%= @program_title %> community, <%= current_user.first_name %>!</p>
             <% if @confirmation_type == 'coach' %>
               <p>We are so pleased to offer you a place among our selective volunteer force. We think you'll be an outstanding coach and will really enjoy this experience leading an inspiring cohort of high-potential, diverse future leaders.</p>
+            <% elsif @confirmation_type == 'volunteer' %>
+              <p>We are so pleased to offer you a place among our volunteer force.</p>
             <% else %>
               <p>We are so pleased to offer you a place in our program. We think you'll be an outstanding Braven Fellow and will really enjoy this experience.</p>
             <% end %>
@@ -37,6 +39,8 @@
             <div class="availability-options">
               <% if @confirmation_type == 'coach' %>
                 <p>We need coaches to lead <%= @program_title %> cohorts at the following times. Please select ONE time slot and then click next. If you are unavailable at the times listed, please select, 'I cannot commit to coach at any of the times listed.' and on the next page, you'll have the option to sign up for our waitlist.</p>
+              <% elsif @confirmation_type == 'volunteer' %>
+                <p>We need volunteers to help our <%= @program_title %> team in the following areas. Please select ONE slot and then click next. If you are unavailable at the times listed, please select, 'I cannot commit to help at any of the times listed.' and on the next page, you'll have the option to sign up for our waitlist.</p>
               <% else %>
                 <p>We have <%= @program_title %> slots available at the following times. Please select ONE time slot and then click next. If you are unavailable at the times listed, please select, 'I cannot commit to participate at any of the times listed.' and on the next page, you'll have the option to sign up for our waitlist.</p>
               <% end %>

--- a/app/views/users/confirm_part_2.html.erb
+++ b/app/views/users/confirm_part_2.html.erb
@@ -21,6 +21,8 @@
             <div class="availability-options">
               <% if @confirmation_type == 'coach' %>
                 <p>Drat. We'll do what we can to include you in the program. In the meantime, we'll add you to our waitlist. Just let us know which of these currently closed section meeting times work for you:</p>
+              <% elsif @confirmation_type == 'volunteer' %>
+                <p>Drat. We'll do what we can to include you. In the meantime, we'll add you to our waitlist. Just let us know which of these currently closed opportunities work for you:</p>
               <% else %>
                 <p>We're sorry we don't have an open slot that fits your schedule. We'd like to add you to our waitlist in case a slot opens up. Just let us know which of these section meeting times work for you, all of which are currently full. Choose as many as you can for the best chance of getting in off the waitlist.</p>
               <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -64,6 +64,18 @@
                     <%= render :partial => 'volunteer', :locals => { :f => f} %>
                   </div>
                   <% end %>
+                  <% if !@hide_other_applicant_types || @user.applicant_type == 'temp_volunteer' %>
+                  <div class="clickable-option">
+                    <% if @hide_other_applicant_types %>
+                      <%= f.radio_button :applicant_type, 'temp_volunteer', required: 'required', style: 'visibility: hidden;' %>
+                    <% else %>
+                      <%= f.radio_button :applicant_type, 'temp_volunteer', required: 'required' %>
+                      <%= f.label :applicant_type_volunteer, 'Interested in volunteering in a smaller capacity with the Braven Accelerator' %>
+                    <% end %>
+                    <%= render :partial => 'temp_volunteer', :locals => { :f => f} %>
+                  </div>
+                  <% end %>
+
                   <% if !@hide_other_applicant_types || @user.applicant_type == 'employer' %>
                   <div class="clickable-option">
                     <% if @hide_other_applicant_types %>
@@ -126,7 +138,7 @@
                   <button type="submit" class="button-primary">
                     <!-- We check the model campaign id to see if they will be auto-mapped based on query params. If so, next
                          step is start application, so it says that. Otherwise, generic "submit" is used. -->
-                    <%= (@user.applicant_type == 'volunteer' || @user.applicant_type == 'undergrad_student') ? "Next: Start Application" : "Submit" %></button>
+                    <%= (@user.applicant_type == 'volunteer' || @user.applicant_type == 'undergrad_student' || @user.applicant_type == 'temp_volunteer') ? "Next: Start Application" : "Submit" %></button>
                 </div>
 
               <% end %>


### PR DESCRIPTION
This is the new signup option, application, and minor tweaks to the confirmation flow for the new volunteer user type. We're going to want to test this carefully on staging and be sure all the mappings to campaigns are updated. For testing, I used coach campaigns with the new volunteer opportunities stuff set. The user type == temp_volunteer is used in a couple places to pull different information from the coach campaign than for coaches proper.

There's one place where I feel iffy on this: if user is temp_volunteer, it assumes the position they are applying for is volunteer, whereas the others are done via the "Application Type" field in the SF campaign. We might want to do separate campaigns for the volunteer to keep this consistent. If so, remind me to change this code - it'll probably work 99% of the time but isn't quite right.