### PR TITLE
send utc to keep dates saner

### DIFF
--- a/app/controllers/admin/assignments_controller.rb
+++ b/app/controllers/admin/assignments_controller.rb
@@ -247,7 +247,7 @@ class Admin::AssignmentsController < Admin::ApplicationController
     rescue ArgumentError
       raise BadDateException, "Row ##{informational_row+1} with date \"#{date_string}\""
     end
-    dt.iso8601
+    dt.utc.iso8601 # do the utc conversion on our end to ensure canvas doesn't try to
   end
 
   # This is the translation when we're exporting from Canvas.


### PR DESCRIPTION
This actually worked on dev, connecting it to staging, to keep the DST stuff sane. If it doesn't work on staging join, maybe we need to update the timezone data there, but finally this little change seems to actually work.