### PR TITLE
Delete from multiple campaigns and send email

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -279,9 +279,9 @@ class Admin::UsersController < Admin::ApplicationController
         end
         client.materialize('CampaignMember')
         cms = SFDC_Models::CampaignMember.find_all_by_ContactId(user.salesforce_id)
-        cms.each do |cm|
-          if campaign_ids_to_delete.has_key?(cm.CampaignId)
-            cm.delete
+        cms.each do |campaign_member|
+          if campaign_ids_to_delete.key?(campaign_member.CampaignId)
+            campaign_member.delete
           end
         end
       end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -273,10 +273,16 @@ class Admin::UsersController < Admin::ApplicationController
         cm.BZ_User_Id__c = ''
         cm.Signup_Date__c = ''
         cm.save
+        campaign_ids_to_delete = {}
+        SFDC_Models::Campaign.query("IsActive=true AND Type IN ('Leadership Coaches', 'Program Participants', 'Volunteer')").each do |camp|
+          campaign_ids_to_delete[camp.Id] = camp.Id
+        end
         client.materialize('CampaignMember')
-        cm = SFDC_Models::CampaignMember.find_by_ContactId(user.salesforce_id)
-        if cm
-          cm.delete
+        cms = SFDC_Models::CampaignMember.find_all_by_ContactId(user.salesforce_id)
+        cms.each do |cm|
+          if campaign_ids_to_delete.has_key?(cm.CampaignId)
+            cm.delete
+          end
         end
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -379,6 +379,11 @@ class UsersController < ApplicationController
       # so they can immediately apply.  This is because our emails are going to spam.  Once
       # that is fixed, undo this.
       sign_in('user', @new_user)
+
+      # we also want to email the people who are automatically confirmed
+      # just so they have a message in their inbox reminding them which
+      # login they used
+      ConfirmationFlow.new_user(@new_user).deliver
     end
 
     redirect_to redirect_to_welcome_path(@new_user)

--- a/app/mailers/confirmation_flow.rb
+++ b/app/mailers/confirmation_flow.rb
@@ -5,6 +5,11 @@ class ConfirmationFlow < ActionMailer::Base
   # needed because gmail was filtering some messages: http://blog.mailgun.com/tips-tricks-avoiding-gmail-spam-filtering-when-using-ruby-on-rails-action-mailer/
   default 'Message-ID' => ->(_v_) { "<#{SecureRandom.uuid}@bebraven.org>" }
 
+  def new_user(user)
+    @user = user
+    mail(to: user.email, subject: 'Welcome to Braven')
+  end
+
   def coach_confirmed(recipient, program_title, program_site, timeslot)
     @recipient = recipient
     @program_title = program_title

--- a/app/views/confirmation_flow/new_user.html.erb
+++ b/app/views/confirmation_flow/new_user.html.erb
@@ -1,0 +1,9 @@
+<p>Welcome to Braven, <%= @user.first_name %>! We are excited to connect with you. You can now log into the site!</p>
+
+<%= link_to 'BeBraven.org', root_url %><br />
+Email: <%= @user.email %><br />
+Password: your chosen password at sign up
+
+<p>Thank you,<br />
+The Braven Team</p>
+

--- a/app/views/confirmation_flow/new_user.text.erb
+++ b/app/views/confirmation_flow/new_user.text.erb
@@ -1,0 +1,8 @@
+Welcome to Braven, <%= @user.first_name %>! We are excited to connect with you. You can now log into the site!
+
+<%= root_url %>
+Email: <%= @user.email %>
+Password: your chosen password at sign up
+
+Thank you,
+The Braven Team


### PR DESCRIPTION
Deletes from all relevant active campaigns when destroying user and also sends an email to a new user who signs up to an auto-confirm campaign.