### PR TITLE
Volunteer Calendar using Calendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ start.sh
 # and i disable ssl because it kept breaking on salesforce
 # obviously don't want that committed but i want it to stay for my testing
 config/initializers/disable_ssl.rb
+
+# I save local versions of files for use in development only as .dev.  Ignore those
+*.dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.2.3
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev postgresql-client
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev postgresql-client vim
 RUN mkdir /app
 WORKDIR /app
 ADD Gemfile /app/Gemfile

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -107,7 +107,9 @@ class Admin::UsersController < Admin::ApplicationController
         :campaign_id => row[0],
         :applicant_type => row[1],
         :university_name => row[2],
-        :bz_region => row[3]
+        :bz_region => row[3],
+        :calendar_email => row[4],
+        :calendar_url => row[5]
       )
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,8 +11,10 @@ class ApplicationController < ActionController::Base
 
   # We moved from beyondz.org to join.bebraven.org but I couldn't
   # get .htaccess redirects working on heroku, so I'm doing it in code.
+  # Don't do it on dev though since you may have setup some funky domain stuff
+  # to develop (e.g. you're using ngrok to expose your server to the internets)
   def redirect_if_old
-    if request.host != Rails.application.secrets.root_domain
+    if Rails.env.production? && request.host != Rails.application.secrets.root_domain
       redirect_to "#{request.protocol}#{Rails.application.secrets.root_domain}#{request.fullpath}", :status => :moved_permanently
     end
   end

--- a/app/controllers/calendly_controller.rb
+++ b/app/controllers/calendly_controller.rb
@@ -1,0 +1,144 @@
+# The purpose of this controller is to handle notifications of calendly events.
+# These events happen when volunteers signup for or cancel their interest in a volunteering opportunity
+class CalendlyController < ApplicationController
+  # this comes from cross site - calendly - and we have our own magic
+  # token to use instead of the random normal CSRF check
+  skip_before_filter :verify_authenticity_token
+
+  # Called by calend.ly when a volunteer signs up for or cancels an event.
+  # Note: you can expose your local dev environment server to the internet for calendly to call using ngrok
+  # Go here: https://ngrok.com/ and download the installer.
+  # Copy the script to /usr/local/bin/
+  #
+  # Now you can expose your local server to the internet
+  # In this example, I'm exposing localhost:3001 using:
+  # ngrok http 3001
+  # That will launch a UI with the address to hit such as:
+  # http://e866da42.ngrok.io -> localhost:3001
+  #
+  # Then I can setup the webhook with calend.ly:
+  # curl --header "X-TOKEN: <your_token>" --data "url=http://e866da42.ngrok.io/calendly/invitee_action?magic_token=test&events[]=invitee.created&events[]=invitee.canceled" https://calendly.com/api/v1/hooks
+  # Note: the token is available here: https://calendly.com/integrations
+  # You can then delete that webhook using:
+  # curl  -X DELETE --header "X-TOKEN: <your_token>" https://calendly.com/api/v1/hooks/<your_hook_id>
+
+  # Sample data POSTed to this hook when something happens in calend.ly
+  # is available here: http://developer.calendly.com/docs/sample-webhook-data
+  #
+  # This function creates or updates the Salesforce records based on the volunteer signup
+  def invitee_action
+    if check_magic_token
+
+      eventType = params[:event]
+      calendar_email = params[:payload][:event][:extended_assigned_to][0][:email] # This is the email of the account used to create the calendar
+      email = params[:payload][:invitee][:email]
+      first_name = params[:payload][:invitee][:first_name]
+      last_name = params[:payload][:invitee][:last_name]
+      event_name = params[:payload][:event_type][:name]
+      start_time = params[:payload][:event][:invitee_start_time_pretty]
+
+      contact = {}
+      contact['FirstName'] = first_name
+      contact['LastName'] = last_name
+      contact['Email'] = email
+
+      applicant_type = 'temp_volunteer'
+      selected_timeslot = "#{event_name}: #{start_time}"
+
+      bz_region = User.get_bz_region(applicant_type, calendar_email)
+      if (bz_region == nil)
+        raise NoRegionMappingException "No bz_region set b/c we haven't mapped the calendar #{calendar_email} to a region for #{applicant_type}"
+      end
+
+      if (eventType == "invitee.created")
+        calendly_url = User.get_calendar_url(bz_region)
+        phone = nil
+        city = nil
+        state = nil
+        sourcing_info = nil
+        params[:payload][:questions_and_answers].each do |qa|
+          if (qa[:question] == 'Phone')
+            phone = qa[:answer]
+          elsif (qa[:question] == 'City that you live in?')
+            city = qa[:answer]
+          elsif (qa[:question] == 'State that you live in?')
+            state = qa[:answer]
+          elsif (qa[:question] == 'How did you hear about us?')
+            sourcing_info = qa[:answer]
+          end
+        end
+
+        # Create a BZ User in this platform
+        current_user = User.find_by_email(email)
+        if (current_user == nil)
+          current_user = User.new(:first_name => first_name, :last_name => last_name, :email => email, :phone => phone, :applicant_type => applicant_type, :city => city, :state => state, :external_referral_url => calendly_url, :bz_region => bz_region)
+        else
+          current_user.bz_region = bz_region
+          current_user.applicant_type = applicant_type
+        end
+        current_user.skip_confirmation!
+        current_user.save!
+
+        # Create the user in salesforce
+        contact['Phone'] = phone
+        contact['Signup_Date__c'] = DateTime.now
+        contact['MailingCity'] = city
+        contact['MailingState'] = state
+        contact['Sourcing_Info__c'] = sourcing_info
+        contact['BZ_Region__c'] = bz_region
+        contact['User_Type__c'] = 'Temp Volunteer'
+        contact['BZ_User_Id__c'] = current_user.id
+        contact['Came_From_to_Visit_Site__c'] = calendly_url
+
+        salesforce = BeyondZ::Salesforce.new
+        existing_salesforce_id = salesforce.exists_in_salesforce(email)
+        client = salesforce.get_client
+        if (existing_salesforce_id != nil)
+          client.update('Contact', existing_salesforce_id, contact)
+        else
+          # Note: for new users that volunteer, we don't create BZ Users.  We just populate a new Salesforce
+          # contact as though it was done manually.  Only Fellows and LCs get BZ Users after this calendly integration goes live.
+          contact['LeadSource'] = 'Volunteer Signup'
+          contact['OwnerId'] = current_user.salesforce_lead_owner_id # Note that if they are already in Salesforce, we assume they have an Owner already.
+          contact = client.create('Contact', contact)
+          existing_salesforce_id = contact.Id
+        end
+
+        current_user.salesforce_id = existing_salesforce_id
+        current_user.skip_confirmation!
+        current_user.save!
+
+        cm = current_user.auto_add_to_salesforce_campaign('Confirmed', selected_timeslot, sourcing_info)
+        if (cm == nil)
+          logger.debug "######## Failed to create Campaign Member for #{current_user.inspect}.  Dunno why though."
+        end
+
+      elsif (eventType == "invitee.canceled")
+        current_user = User.find_by_email(email)
+        if (current_user != nil)
+          current_user.bz_region = bz_region
+          current_user.applicant_type = applicant_type
+          cancellation_reason = params[:payload][:invitee][:cancel_reason]
+          current_user.cancel_volunteer_signup(selected_timeslot, cancellation_reason)
+        else
+          logger.warn "No user with email = #{email} found -- NOOP"
+        end
+
+      else
+        logger.warn "Unrecognized event type found: #{eventType} -- NOOP";
+      end
+
+    end
+
+    render plain: 'OK'
+  end
+
+  # a simple filter to keep web crawlers from triggering this
+  # needlessly
+  def check_magic_token
+    params[:magic_token] == Rails.application.secrets.calendly_magic_token
+  end
+end
+
+class NoRegionMappingException < Exception
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -346,15 +346,15 @@ class UsersController < ApplicationController
       # We don't create a user now for Temp Volunteers.  Instead, we send them to calendly and
       # when they signup for an event, that calls into the calendly_controller to create a new
       # user.
-      if (user[:applicant_type] == 'temp_volunteer')
+      if user[:applicant_type] == 'temp_volunteer'
         calendar_url = User.get_calendar_url(user[:bz_region])
-        if (calendar_url == nil)
+        if calendar_url.nil?
           raise NoCalendarMappingException, "No calendar_url found for bz_region #{user[:bz_region]}"
         end
 
         # TODO: URL escape the names and email.  especially the "+" in an email
-        #Example URL:
-        #path = "https://calendly.com/stagingbraven?first_name=#{user[:first_name]}&last_name=#{user[:last_name]}&email=#{user[:email]}"
+        # Example URL:
+        # path = "https://calendly.com/stagingbraven?first_name=#{user[:first_name]}&last_name=#{user[:last_name]}&email=#{user[:email]}"
         path = "#{calendar_url}?first_name=#{user[:first_name]}&last_name=#{user[:last_name]}&email=#{user[:email]}"
         redirect_to path
         return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -319,9 +319,7 @@ class UsersController < ApplicationController
       :last_name,
       :email,
       :password,
-
       :phone,
-
       :applicant_type,
       :applicant_details,
       :applicant_comments,
@@ -345,6 +343,22 @@ class UsersController < ApplicationController
     user[:university_name] = params[:undergrad_university_name] if user[:university_name] == 'other'
 
     if !user[:applicant_type].nil?
+      # We don't create a user now for Temp Volunteers.  Instead, we send them to calendly and
+      # when they signup for an event, that calls into the calendly_controller to create a new
+      # user.
+      if (user[:applicant_type] == 'temp_volunteer')
+        calendar_url = User.get_calendar_url(user[:bz_region])
+        if (calendar_url == nil)
+          raise NoCalendarMappingException, "No calendar_url found for bz_region #{user[:bz_region]}"
+        end
+
+        # TODO: URL escape the names and email.  especially the "+" in an email
+        #Example URL:
+        #path = "https://calendly.com/stagingbraven?first_name=#{user[:first_name]}&last_name=#{user[:last_name]}&email=#{user[:email]}"
+        path = "#{calendar_url}?first_name=#{user[:first_name]}&last_name=#{user[:last_name]}&email=#{user[:email]}"
+        redirect_to path
+        return
+      end
       @new_user = User.new(user)
       unless user[:applicant_type] == 'undergrad_student' || user[:applicant_type] == 'volunteer' || user[:applicant_type] == 'temp_volunteer'
         # Partners, employers, and others are reached out to manually instead of confirming
@@ -428,4 +442,7 @@ class UsersController < ApplicationController
       'Wisconsin' => 'WI', 'Wyoming' => 'WY'
     }
   end
+end
+
+class NoCalendarMappingException < Exception
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -180,7 +180,7 @@ class User < ActiveRecord::Base
     # Does this user already exist on Salesforce as a manually entered contact?
     # If we, we want to use it directly instead of trying to create a lead.
     existing_salesforce_id = salesforce.exists_in_salesforce(email)
-    if !existing_salesforce_id.nil?
+    unless existing_salesforce_id.nil?
       self.salesforce_id = existing_salesforce_id
     end
 
@@ -329,7 +329,7 @@ class User < ActiveRecord::Base
           cm = SFDC_Models::CampaignMember.find_by_ContactId_and_CampaignId(salesforce_id, salesforce_campaign_id)
           if !cm.nil?
             cm.Candidate_Status__c = candidate_status unless candidate_status.nil?
-            if !selected_timeslot.nil?
+            unless selected_timeslot.nil?
               if cm.Volunteer_Event_Signups__c.nil? || cm.Volunteer_Event_Signups__c == ''
                 # This is the first event they're signing up for.
                 cm.Volunteer_Event_Signups__c = selected_timeslot

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ActiveRecord::Base
   # a default if it doesn't exist for our combination of fields.
   #
   # Returns a user's email address.
-  def lead_owner
+  def lead_owner_email
     # The 'other' option on the signup form should be accessible here too.
     # So if we see the keyword 'other' in the mapping, we match that to anything
     # except the item on the list we have.
@@ -89,8 +89,41 @@ class User < ActiveRecord::Base
     if mapping.empty?
       return Rails.application.secrets.default_lead_owner
     end
-
     mapping.first.lead_owner
+  end
+
+  def salesforce_lead_owner_id
+    sf = BeyondZ::Salesforce.new
+    client = sf.get_client
+
+    # Note on the SOQL queries rather than ActiveRecord style finds:
+    #
+    # SFDC_Models::User.find_by_Email(lead_owner)
+    # the model didn't work though because the materialize call
+    # conflicted their User with our User (the namespace wasn't used
+    # properly!) So doing SOQL instead. The sub call is to escape the quotes
+    # to mitigate SQL injection (of course, this comes from our code anyway,
+    # so there should be no security risk, but I just prefer to be a bit
+    # defensive.)
+    #
+    # Moreover, since the databasedotcom gem tries to materialize objects... and
+    # has a bug where it ignores the module if it finds a class in global... it
+    # conflicts with our User class too! So the query function is unusable :(
+    # Instead, I'll go one level lower and use their http method, just like the
+    # implementation (line 182 of databasedotcom/client.rb)
+    salesforce_lead_owner = client.http_get("/services/data/v#{client.version}/query?q=" \
+        "SELECT Id FROM User WHERE Email = '#{lead_owner_email.sub('\'', '\'\'')}'")
+    sf_answer = JSON.parse(salesforce_lead_owner.body)
+    salesforce_lead_owner = sf_answer['records']
+    salesforce_lead_owner = salesforce_lead_owner.empty? ? nil : salesforce_lead_owner.first
+
+    if salesforce_lead_owner
+      return salesforce_lead_owner['Id']
+    else
+      # this is the user id we're logged into Salesforce as to use as
+      # a last-resort owner if the other one fails
+      return client.user_id
+    end
   end
 
   # Salesforce IDs are a bit weird because they come in both 15 character
@@ -146,56 +179,22 @@ class User < ActiveRecord::Base
 
     # Does this user already exist on Salesforce as a manually entered contact?
     # If we, we want to use it directly instead of trying to create a lead.
-
-    salesforce_existing_record = client.http_get("/services/data/v#{client.version}/query?q=" \
-      "SELECT Id FROM Contact WHERE Email = '#{email.sub('\'', '\'\'')}'")
-    sf_answer = JSON.parse(salesforce_existing_record.body)
-    salesforce_existing_record = sf_answer['records']
+    existing_salesforce_id = salesforce.exists_in_salesforce(email)
+    if (existing_salesforce_id != nil)
+      self.salesforce_id = existing_salesforce_id
+    end
 
     contact = {}
-
-    unless salesforce_existing_record.empty?
-      self.salesforce_id = salesforce_existing_record.first['Id']
-    end
-    # end
 
     contact['FirstName'] = first_name
     contact['LastName'] = last_name
     contact['Email'] = email
 
-    # Note on the SOQL queries rather than ActiveRecord style finds:
-    #
-    # SFDC_Models::User.find_by_Email(lead_owner)
-    # the model didn't work though because the materialize call
-    # conflicted their User with our User (the namespace wasn't used
-    # properly!) So doing SOQL instead. The sub call is to escape the quotes
-    # to mitigate SQL injection (of course, this comes from our code anyway,
-    # so there should be no security risk, but I just prefer to be a bit
-    # defensive.)
-    #
-    # Moreover, since the databasedotcom gem tries to materialize objects... and
-    # has a bug where it ignores the module if it finds a class in global... it
-    # conflicts with our User class too! So the query function is unusable :(
-    # Instead, I'll go one level lower and use their http method, just like the
-    # implementation (line 182 of databasedotcom/client.rb)
+    # If the user is already on salesforce btw, we assume they are already
+    # assigned an owner (this is likely the case when they are manually entered
+    # by someone who has already formed a relationship with that person)
     unless salesforce_id
-      # If the user is already on salesforce btw, we assume they are already
-      # assigned an owner (this is likely the case when they are manually entered
-      # by someone who has already formed a relationship with that person)
-      salesforce_lead_owner = client.http_get("/services/data/v#{client.version}/query?q=" \
-        "SELECT Id FROM User WHERE Email = '#{lead_owner.sub('\'', '\'\'')}'")
-      sf_answer = JSON.parse(salesforce_lead_owner.body)
-      salesforce_lead_owner = sf_answer['records']
-      salesforce_lead_owner = salesforce_lead_owner.empty? ? nil : salesforce_lead_owner.first
-
-      if salesforce_lead_owner
-        contact['OwnerId'] = salesforce_lead_owner['Id']
-      else
-        # this is the user id we're logged into Salesforce as to use as
-        # a last-resort owner if the other one fails
-        contact['OwnerId'] = client.user_id
-      end
-
+      contact['OwnerId'] = salesforce_lead_owner_id
       contact['IsUnreadByOwner'] = false
     end
 
@@ -296,11 +295,15 @@ class User < ActiveRecord::Base
     end
   end
 
-  def auto_add_to_salesforce_campaign
+  def auto_add_to_salesforce_campaign(candidate_status = nil, selected_timeslot = nil, sourcing_info = nil)
     # We may also need to add them to a campaign if certain things
     # are right.
     cm = {}
     cm['CampaignId'] = salesforce_campaign_id
+    cm['Candidate_Status__c'] = candidate_status unless candidate_status == nil
+    cm['Volunteer_Event_Signups__c'] = selected_timeslot unless selected_timeslot == nil
+    cm['Sourcing_Info__c'] = sourcing_info unless sourcing_info == nil
+    cm['Opted_Out_Reason__c'] = '' # Reset this in case they cancel but then signup again.
 
     if cm['CampaignId']
       # Can't use client.materialize because it sets the checkboxes to nil
@@ -311,17 +314,38 @@ class User < ActiveRecord::Base
       cm['ContactId'] = salesforce_id
 
       begin
-        client.create('CampaignMember', cm)
+        cm = client.create('CampaignMember', cm)
       rescue Databasedotcom::SalesForceError => e
         # If this failure happens, it is almost certainly just because they
         # are already in the campaign - probably because we invited them from
         # Salesforce, so we can simply proceed normally and let the campaign
         # member check in the welcome page show them next steps, assuming
         # apply now will work until triggers hit us to say otherwise.
-
-        # I warn just because rubocop is annoying and doesn't want the exception
-        # do disappear, and it doesn't hurt to log, but we don't really care.
-        warn e
+        #
+        # However, for Temp Volunteers they maybe rescheduling or signing up again after cancelling, so we want to
+        # update their record with the new information
+        if (applicant_type == 'temp_volunteer')
+          client.materialize('CampaignMember')
+          cm = SFDC_Models::CampaignMember.find_by_ContactId_and_CampaignId(salesforce_id, salesforce_campaign_id)
+          if (cm != nil)
+            cm.Candidate_Status__c = candidate_status unless candidate_status == nil
+            if (selected_timeslot != nil)
+              if (cm.Volunteer_Event_Signups__c == nil || cm.Volunteer_Event_Signups__c == '')
+                # This is the first event they're signing up for.
+                cm.Volunteer_Event_Signups__c = selected_timeslot
+              else
+                # If they signup for a second event, create a line delimited list of events they signed up for.
+                cm.Volunteer_Event_Signups__c = "#{cm.Volunteer_Event_Signups__c}\n#{selected_timeslot}"
+              end
+            end
+            cm.Sourcing_Info__c = sourcing_info unless sourcing_info == nil
+            # Reset this in case they cancel but signup again.
+            cm.Opted_Out_Reason__c = ''
+            cm.save
+          else
+            logger.debug "########## No CampaignMember found with salesforce_id = #{salesforce_id} and salesforce_campaign_id = #{salesforce_campaign_id}.  Failed to update their volunteer signup info"
+          end
+        end
       end
 
       # The apply now enabled *should* be set by the SF triggers
@@ -329,9 +353,65 @@ class User < ActiveRecord::Base
       # response to the user.
       self.apply_now_enabled = true
       self.save!
+      return cm
+    else
+      logger.debug "No 'salesforce_campaign_id' found for #{self.inspect}.  Can't create a Campaign Member."
+      return nil
     end
   end
 
+  def cancel_volunteer_signup(selected_timeslot, cancellation_reason = nil)
+    begin
+      sf = BeyondZ::Salesforce.new
+      client = sf.get_client
+      client.materialize('CampaignMember')
+      cm = SFDC_Models::CampaignMember.find_by_ContactId_and_CampaignId(salesforce_id, salesforce_campaign_id)
+      if (cm != nil)
+        if (cm.Volunteer_Event_Signups__c == selected_timeslot)
+          # Exact match means they are cancelling the only timeslot they signed up for
+          cm.Volunteer_Event_Signups__c = ''
+          cm.Candidate_Status__c = 'Opted Out'
+          cm.Opted_Out_Reason__c = 'Cancelled Volunteer Signup'
+        elsif (cm.Volunteer_Event_Signups__c != nil && cm.Volunteer_Event_Signups__c.include?(selected_timeslot))
+          # If this timeslot is in the list, they signed up for multiple and we just want to remove the one
+          # they're cancelling from the list.
+          # Note: this handles both \r\n and just \n since they may manually edit the list in an editor
+          # that inserts a carriage return
+
+          # First handle removing it from the beginning or middle of the list
+          cm.Volunteer_Event_Signups__c.slice! "#{selected_timeslot}\r\n"
+          cm.Volunteer_Event_Signups__c.slice! "#{selected_timeslot}\n"
+          # Now handle removing it from the end of the list.
+          cm.Volunteer_Event_Signups__c.slice! "\r\n#{selected_timeslot}"
+          cm.Volunteer_Event_Signups__c.slice! "\n#{selected_timeslot}"
+        end
+        cm.save
+
+        sf = BeyondZ::Salesforce.new
+        client = sf.get_client
+        campaign = sf.load_cached_campaign(cm.CampaignId)
+        client.materialize('Task')
+        task = SFDC_Models::Task.new
+        task.OwnerId = campaign.OwnerId
+        task['Subject'] = "Cancelled Volunteer Signup for #{first_name} #{last_name}: #{selected_timeslot}"
+        description = "This person signed up for '#{selected_timeslot}' but then cancelled"
+        description = "#{description} citing this as the reason\n\n'#{cancellation_reason}'" unless (cancellation_reason == nil || cancellation_reason == '')
+        task['Description'] = description
+        task['ActivityDate'] =  DateTime.now
+        task.WhoId = cm.ContactId
+        task.WhatId = cm.CampaignId
+        task.Status = 'Completed'
+        task['CampaignMemberId__c'] = cm.Id
+        task.IsReminderSet = false
+        task.IsRecurrence = false
+        task.save
+      else
+        logger.debug "No CampaignMember found with salesforce_id = #{salesforce_id} and salesforce_campaign_id = #{salesforce_campaign_id}.  Failed to set Candidate Status to cancel their Volunteer Signup"
+      end
+    rescue Databasedotcom::SalesForceError => e
+      logger.warn "###### Caught Databasedotcom::SalesForceError #{e.inspect} -- Failed to update CampaignMember and record a Task of the cancellation for #{first_name} #{last_name} - #{selected_timeslot}"
+    end
+  end
 
   def salesforce_applicant_type
     case applicant_type
@@ -360,10 +440,48 @@ class User < ActiveRecord::Base
     )
 
     if mapping.empty?
+      logger.debug "########## No campaign mapping found for #{university_name}, #{bz_region}, #{applicant_type}"
       return nil
     end
 
     mapping.first.campaign_id
+  end
+
+  # The BZ Region that this user is mapped to given their Calendar Email and Application Type
+  def self.get_bz_region(applicant_type, calendar_email)
+    mapping = CampaignMapping.where(
+      :calendar_email => calendar_email,
+      :applicant_type => applicant_type
+    )
+
+    if mapping.empty?
+      logger.debug "########## No BZ Region found for this calendar_email = #{calendar_email} and applicant_type=#{applicant_type}."
+      return nil
+    end
+
+    mapping.first.bz_region
+
+  end
+
+  # Returns the URL of the calendly calendar of volunteer events for the specified
+  # bz_region
+  def self.get_calendar_url(bz_region)
+    mapping = CampaignMapping.where(
+      :bz_region => bz_region,
+      :applicant_type => 'temp_volunteer'
+    )
+
+    if mapping.empty?
+      logger.debug "########## No calendar_email found for this bz_region = #{bz_region}"
+      return nil
+    end
+
+    # Examples:
+    # https://calendly.com/run-volunteers
+    # https://calendly.com/sjsu-volunteers
+    # https://calendly.com/stagingbraven
+
+    mapping.first.calendar_url
   end
 
   # validates :anticipated_graduation, presence: true, if: :graduation_required?
@@ -423,6 +541,9 @@ class User < ActiveRecord::Base
     create_child_skeleton_rows
   end
 
+  # TODO: the assignments, tasks, and submissions code is obsolete. This takes up room in the database. 
+  # Do a project to remove the objects and tables.
+  #
   # This will create the skeletons for assignments, tasks,
   # and submissions based on the definitions. We should run
   # this whenever a user is created or a definition is added.

--- a/app/views/admin/users/campaign_mapping.html.erb
+++ b/app/views/admin/users/campaign_mapping.html.erb
@@ -10,27 +10,29 @@
 
 <p>For example, a volunteer should have a blank university name. Only the region column should be filled. By contrast, a student should have a blank BZ Region, with a university name filled instead.</p>
 
+<p>Calendar Email and URL is used for temp_volunteer applicants to map the email of the owner of the calendar they signed up on to a BZ Region and Campaign.  Setting it for other applicant types will have no effect.</p>
+
 <p>Make sure you check the form for the spelling of the fields, as they need to match exactly.</p>
 
 <table class="sample-csv" width="600"><caption>Expected format</caption>
   <thead><tr>
-      <th>Campaign ID</th><th>Applicant type</th><th>University Name</th><th>BZ Region</th>
+      <th>Campaign ID</th><th>Applicant type</th><th>University Name</th><th>BZ Region</th><th>Calendar Email</th><th>Calendar URL</th>
   </tr></thead>
   <tbody>
     <tr>
-      <td>7011700000056Pf</td><td>undergrad_student</td><td>San Jose State University</td><td></td>
+      <td>7011700000056Pf</td><td>undergrad_student</td><td>San Jose State University</td><td></td><td></td><td></td>
     </tr>
     <tr>
-      <td>70117000000782T</td><td>volunteer</td><td></td><td>Chicago Area</td>
+      <td>70117000000782T</td><td>volunteer</td><td></td><td>Chicago Area</td><td></td><td></td>
     </tr>
     <tr>
-      <td>701170000007DP3</td><td>volunteer</td><td></td><td>Students For Education Reform Fellowship Program</td>
+      <td>701170000007DP3</td><td>volunteer</td><td></td><td>Students For Education Reform Fellowship Program</td><td></td><td></td>
     </tr>
     <tr>
-      <td>7011700000056ww</td><td>volunteer</td><td></td><td>San Francisco Bay Area, San Jose</td>
+      <td>7011700000056ww</td><td>volunteer</td><td></td><td>San Francisco Bay Area, San Jose</td><td></td><td></td>
     </tr>
     <tr>
-      <td>1234567890abcde</td><td>temp_volunteer</td><td></td><td>New Jersey - Rutgers</td>
+      <td>1234567890abcde</td><td>temp_volunteer</td><td></td><td>New Jersey - Rutgers</td><td>run-volunteers@bebraven.org</td><td>https://calendly.com/run-volunteers</td>
     </tr>
   </tbody>
 </table>

--- a/app/views/users/_temp_volunteer.html.erb
+++ b/app/views/users/_temp_volunteer.html.erb
@@ -10,33 +10,5 @@
   <% else %>
     <%= f.hidden_field :bz_region, :value => params[:user][:bz_region] %>
   <% end %>
-
-
-  <section>
-    <div>
-      Profession / job title:
-    </div>
-    <div class="col-sm-7">
-      <%= f.text_field :profession, :class => 'form-control', :maxlength => '70' %>
-    </div>
-  </section>
-  <section>
-    <div>
-      Company:
-    </div>
-    <div class="col-sm-7">
-      <%= f.text_field :company, :class => 'form-control', :maxlength => '70' %>
-    </div>
-  </section>
-
-  <section>
-    <div class="required">
-      Please create a password to protect any personal information you may provide us.
-    </div>
-    <div class="col-sm-7">
-      <%= f.password_field :password, :class => 'form-control', placeholder: 'Create a password', pattern: '.{4,}', title: 'make a password at least four characters long', :required => 'required' %>
-    </div>
-  </section>
-
 </div>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,9 +3,15 @@
     <div class="section-container">
       <section>
         <div class="col-sm-6">
-          <h1>
-            Join Us
-          </h1>
+          <% if @user.applicant_type == 'temp_volunteer' %>
+            <h1>
+            Volunteer With Us
+            </h1>
+          <% else %>
+            <h1>
+              Join Us
+            </h1>
+          <% end %>
 
           <% if !@hide_other_applicant_types %>
           <p class="lead">
@@ -141,7 +147,7 @@
                     <% if(@user.applicant_type == 'volunteer' || @user.applicant_type == 'undergrad_student') %>
                       Next: Start Application
                     <% elsif @user.applicant_type == 'temp_volunteer'%>
-                      Next: Register
+                      Next: Choose Event
                     <% else %>
                       Submit
                     <% end %>
@@ -154,6 +160,7 @@
         </div>
 
         <div class="col-sm-4 col-sm-offset-2 hidden-xs">
+        <% if @user.applicant_type != 'temp_volunteer' %>
           <h2>Why Join?</h2>
           <blockquote>
             <p>&ldquo;You become part of a team that could actually make a difference. You learn that you have a story and how to tell it. You meet lots of highly motivated, inspiring people.&rdquo;</p>
@@ -163,6 +170,12 @@
             <p>&ldquo;Braven had provided me with innumerable opportunities for personal and professional growth, but the Capstone project took our learning experiences beyond that of our own and empowered me to give back to my community. I really appreciated this opportunity, it was a great learning experience in regards to leadership for me as a project manager.&rdquo;</p>
             <footer>Kelly Hernandez, Braven Fellow '14</footer>
           </blockquote>
+        <% else %>
+          <h2>Why Volunteer?</h2><!-- Note: this only shows if you use the applicant_type=temp_volunteer query param -->
+          <p>You'll have the opportunity to impact promising college students as they take
+          their first steps into the professional world. You'll also meet like-minded volutneers from your
+          area to help make a difference and have fun while doing it!</p>
+        <% end %>
         </div>
       </section>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ BeyondzPlatform::Application.routes.draw do
   get '/salesforce/change_campaigns', to: 'salesforce#change_campaigns'
   post '/salesforce/change_campaigns', to: 'salesforce#change_campaigns'
 
+  # Add hook for calendly to call when Invitees either signup for or cancel their signup for an event
+  post '/calendly/invitee_action', to:'calendly#invitee_action'
+
   resources :feedback
   resources :comments
   get '/signup', to: 'users#new' # This is not really a proper REST path, but we don't have a show operation so this is for convenience (e.g. talking to someong at an event: "hey just go to bz.org/signup to signup!")

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -29,6 +29,7 @@ development:
   salesforce_security_token: <%= ENV['SALESFORCE_SECURITY_TOKEN'] %>
   default_lead_owner: <%= ENV['DEFAULT_LEAD_OWNER'] %>
   salesforce_magic_token: <%= ENV['SALESFORCE_MAGIC_TOKEN'] %>
+  calendly_magic_token: <%= ENV['CALENDLY_MAGIC_TOKEN'] %>
   cookie_domain: <%= ENV['COOKIE_DOMAIN'] %>
   google_spreadsheet_client_id: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_ID'] %>
   google_spreadsheet_client_secret: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_SECRET'] %>
@@ -73,6 +74,7 @@ test:
   salesforce_security_token: <%= ENV['SALESFORCE_SECURITY_TOKEN'] %>
   default_lead_owner: <%= ENV['DEFAULT_LEAD_OWNER'] %>
   salesforce_magic_token: <%= ENV['SALESFORCE_MAGIC_TOKEN'] %>
+  calendly_magic_token: <%= ENV['CALENDLY_MAGIC_TOKEN'] %>
   cookie_domain: <%= ENV['COOKIE_DOMAIN'] %>
   google_spreadsheet_client_id: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_ID'] %>
   google_spreadsheet_client_secret: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_SECRET'] %>
@@ -111,6 +113,7 @@ staging:
   salesforce_security_token: <%= ENV['SALESFORCE_SECURITY_TOKEN'] %>
   default_lead_owner: <%= ENV['DEFAULT_LEAD_OWNER'] %>
   salesforce_magic_token: <%= ENV['SALESFORCE_MAGIC_TOKEN'] %>
+  calendly_magic_token: <%= ENV['CALENDLY_MAGIC_TOKEN'] %>
   cookie_domain: <%= ENV['COOKIE_DOMAIN'] %>
   google_spreadsheet_client_id: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_ID'] %>
   google_spreadsheet_client_secret: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_SECRET'] %>
@@ -149,6 +152,7 @@ production:
   salesforce_security_token: <%= ENV['SALESFORCE_SECURITY_TOKEN'] %>
   default_lead_owner: <%= ENV['DEFAULT_LEAD_OWNER'] %>
   salesforce_magic_token: <%= ENV['SALESFORCE_MAGIC_TOKEN'] %>
+  calendly_magic_token: <%= ENV['CALENDLY_MAGIC_TOKEN'] %>
   cookie_domain: <%= ENV['COOKIE_DOMAIN'] %>
   google_spreadsheet_client_id: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_ID'] %>
   google_spreadsheet_client_secret: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_SECRET'] %>

--- a/db/migrate/20161209154600_add_calendar_email_to_campaign_mappings.rb
+++ b/db/migrate/20161209154600_add_calendar_email_to_campaign_mappings.rb
@@ -1,0 +1,6 @@
+class AddCalendarEmailToCampaignMappings < ActiveRecord::Migration
+  def change
+    add_column :campaign_mappings, :calendar_email, :string
+    add_column :campaign_mappings, :calendar_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161108183542) do
+ActiveRecord::Schema.define(version: 20161209154600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "assignment_definitions", force: true do |t|
     t.string   "title"
@@ -56,6 +57,8 @@ ActiveRecord::Schema.define(version: 20161108183542) do
     t.string   "bz_region"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "calendar_email"
+    t.string   "calendar_url"
   end
 
   create_table "coach_students", force: true do |t|

--- a/docker-compose/.env-docker
+++ b/docker-compose/.env-docker
@@ -7,7 +7,7 @@ DATABASE_PASSWORD=
 
 # This controls what links in emails sent point to as well as redirects
 # from old domain names.
-ROOT_DOMAIN=join.docker
+ROOT_DOMAIN=joinweb
 
 # This controls the From address in outgoing emails.  
 # For Amazon SES, it must be a verified sender email.
@@ -20,12 +20,21 @@ STAFF_NOTIFICATION_EMAIL=brian.sadler@beyondz.org
 
 # Information for Canvas integration
 CANVAS_ACCESS_TOKEN=6djSpJ0qrs9sTdSByo61j6geqn0Un32DiQbvwJXakaTDaNgXdAIXNSldCOKDThee
-CANVAS_SERVER=canvas.docker
-CANVAS_PORT=80
+CANVAS_SERVER=canvasweb
+CANVAS_PORT=3000
 CANVAS_USE_SSL=false
 CANVAS_ALLOW_SELF_SIGNED_SSL=true
 
-SSO_URL=http://sso.docker/
+SSO_URL=http://ssoweb:3002/
+
+# This is used to register the webhook with calend.ly so it can call in when volunteers
+# signup for or cancel their commitment to volunteer at a Braven event.
+CALENDLY_MAGIC_TOKEN=test
+
+# Note: you must use the command shown here: http://developer.calendly.com/docs/webhook-subscriptions
+# to register a webhook with the calendly staging account so it will
+# callback into the Join server when people volunteer for or cancel an event.
+# For some reason, when I put the command in here it wasn't recognized as a comment?!?
 
 # This is the default owner of people who sign up through the
 # website - used in the case of an incomplete assignment table
@@ -43,13 +52,13 @@ SALESFORCE_MAGIC_TOKEN=test
 # be our top-level domain that matches both the main site
 # and SSO - the only correct setting right now for both
 # staging and production is ".beyondz.org".
-COOKIE_DOMAIN=docker
+COOKIE_DOMAIN=localhost
 
 # This is the host for our OSQA Question and Answers website where students, coaches, and staff can
 # ask and answer questions related to the program.
 # TODO: tmp for testing.  we don't have a staging version, so unset this when testing is over to prevent
 # staging from posting to the real site.
-QA_HOST=help.docker
+QA_HOST=helpweb:3006
 
 # This is an arbitrary token we make up ourselves and put on this and in the QA config
 # it is random characters that just need to match on both sides.

--- a/docker-compose/scripts/console.rb
+++ b/docker-compose/scripts/console.rb
@@ -1,0 +1,3 @@
+#!bin/bash
+# Put a file called script.rb in the app root and this will execute it in the console
+docker-compose -f ../docker-compose-join.yml run --rm joinweb /bin/bash -c "bundle exec rails runner \"eval(File.read '/app/script.rb')\""

--- a/env.sample
+++ b/env.sample
@@ -107,6 +107,11 @@ DEFAULT_LEAD_OWNER=<staff email address>
 # but it should keep casual url scrapers from setting off our processes.
 SALESFORCE_MAGIC_TOKEN=<alphanumeric randomness>
 
+# This is used to register the webhook with calend.ly so it can call in when volunteers
+# signup for or cancel their commitment to volunteer at a Braven event.
+# It must be used when registering the webhook using the instructions in calendly_controller.rb
+CALENDLY_MAGIC_TOKEN=<alphanumber randomness>
+
 # This is the cookie domain for communication. It should
 # be our top-level domain that matches both the main site
 # and SSO - the only correct setting right now for both


### PR DESCRIPTION
This cuts over the volunteer signup options to use Calendly instead.  They should be sent directly to a Calendly calendar, like https://calendly.com/run-volunteers or https://calendly.com/sjsu-volunteers which has a webhook registered to call into this code using something like: '''curl --header "X-TOKEN: <your_token>" --data "url=https://join.bebraven.org/calendly/invitee_action?magic_token=<insert_token>&events[]=invitee.created&events[]=invitee.canceled" htt   pps://calendly.com/api/v1/hooks'''  When they signup, this code creates a new user and adds their signup info to Salesforce.