### PR TITLE
JLB mailchimp email updates - v2

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ class User < ActiveRecord::Base
   validates :last_name, presence: true
 
   before_save :capitalize_name
-  before_save :update_mailchimp, if: :email_changed?
+  before_save :update_mailchimp
   
   def capitalize_name
     self.first_name = first_name.split.map(&:capitalize).join(' ') unless first_name.nil?
@@ -65,6 +65,9 @@ class User < ActiveRecord::Base
   end
   
   def update_mailchimp
+    return true if new_record?
+    return true unless email_changed?
+    
     mailchimp = BeyondZ::Mailchimp.new(changed_attributes['email'])
     mailchimp.update(attributes['email'])
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,14 @@ class User < ActiveRecord::Base
     return true unless email_changed?
     
     mailchimp = BeyondZ::Mailchimp.new(changed_attributes['email'])
-    mailchimp.update(attributes['email'])
+
+    success = mailchimp.update(attributes['email'])
+    
+    unless success
+      self.errors[:email] << "could not be updated on MailChimp"
+    end
+    
+    success
   end
 
   # Finds the lead owner from the uploaded spreadsheet mapping, or returns


### PR DESCRIPTION
This most recent PR addresses the issues found in staging testing:

* new users are now exempt from updating a mailchimp record that doesn't exist yet. Direct mailchimp record creation is on the docket.
* A failed mailchimp e-mail update will halt the save, and prevent the user record from being updated. That was true before, but now it will create an ActiveRecord error to be displayed to the user.

The scary part of this is that a failed mailchimp update won't reverse the update in salesforce. I'd need to know more about how our salesforce integration works in order to account for that. It's not likely to be a big issue though, so I didn't know if it was worth holding up this PR.