### PR TITLE
always return true from mailchimp update

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,7 +76,8 @@ class User < ActiveRecord::Base
       self.errors[:email] << "could not be updated on MailChimp"
     end
     
-    success
+    # for now, always return true to prevent AR update failure
+    true
   end
 
   # Finds the lead owner from the uploaded spreadsheet mapping, or returns


### PR DESCRIPTION
This will prevent activerecord from stopping the update process and rolling back the AR record change. So even if we don't find the user in mailchimp, because they don't exist there yet, it won't kill the whole update.  A very near future task will be adding users to mailchimp directly, at which time this won't be a problem anymore.

![confused_chimp](https://user-images.githubusercontent.com/12893/37611475-71769d90-2b70-11e8-9b11-0341e50a166d.gif)
