### PR TITLE
Fix Mailchimp Update

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,11 +67,12 @@ class User < ActiveRecord::Base
   def update_mailchimp
     # don't update for a new record, it doesn't exist in mailchimp yet
     return true if new_record?
-    
-    # don't update unless e-mail has changed
-    return true unless email_changed?
 
     mailchimp = BeyondZ::Mailchimp.new(self)
+    
+    # don't update unless an updateable field has changed
+    return true unless mailchimp.requires_update?
+    
     success_status = mailchimp.update
 
     # for now, assume success until retro-sync can be performed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,19 +65,23 @@ class User < ActiveRecord::Base
   end
   
   def update_mailchimp
+    # don't update for a new record, it doesn't exist in mailchimp yet
     return true if new_record?
+    
+    # don't update unless e-mail has changed
     return true unless email_changed?
-    
-    mailchimp = BeyondZ::Mailchimp.new(changed_attributes['email'])
 
-    success = mailchimp.update(attributes['email'])
+    mailchimp = BeyondZ::Mailchimp.new(self)
+    success_status = mailchimp.update
+
+    # for now, assume success until retro-sync can be performed
+    success_status = true
     
-    unless success
+    unless success_status
       self.errors[:email] << "could not be updated on MailChimp"
     end
     
-    # for now, always return true to prevent AR update failure
-    true
+    success_status
   end
 
   # Finds the lead owner from the uploaded spreadsheet mapping, or returns

--- a/db/migrate/20180323175937_add_mailchimp_id_to_users.rb
+++ b/db/migrate/20180323175937_add_mailchimp_id_to_users.rb
@@ -1,5 +1,0 @@
-class AddMailchimpIdToUsers < ActiveRecord::Migration
-  def change
-    add_column :users, :mailchimp_id, :string
-  end
-end

--- a/db/migrate/20180323175937_add_mailchimp_id_to_users.rb
+++ b/db/migrate/20180323175937_add_mailchimp_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddMailchimpIdToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :mailchimp_id, :string
+  end
+end

--- a/lib/mailchimp.rb
+++ b/lib/mailchimp.rb
@@ -8,6 +8,7 @@ module BeyondZ
     
     HOST = "https://us11.api.mailchimp.com"
     VERSION = '3.0'
+    UPDATEABLE_FIELDS = ['email', 'first_name', 'last_name']
     
     def initialize(user)
       @user = user
@@ -59,13 +60,15 @@ module BeyondZ
       @mailchimp_record
     end
     
+    def requires_update?
+      !(user.changed_attributes.keys & UPDATEABLE_FIELDS).empty?
+    end
+    
     private
     
     def hex_digest(email=nil)
       Digest::MD5.hexdigest(email || user.email)
     end
-    
-    def
     
     def record_via_email(email)
       uri = URI("#{HOST}/#{VERSION}/lists/#{list_id}/members/#{hex_digest(email)}")


### PR DESCRIPTION
The mailchimp library has been rewritten substantially to be more robust, and be more forward-compatible with our plans to create new mailchimp records directly in a future task. 

Sadly, we're not able to obtain an immutable record ID from mailchimp the way we do from salesforce - they simply don't exist. The only available ID is merely the MD5 hexadecimal hash of the e-mail address itself. So updating the e-mail means the ID itself changes.

The library makes its best attempt at locating a user's corresponding mailchimp record. If successful, it is then able to sync all updateable fields from our user record to mailchimp - currently the e-mail, first name, and last name of the user.

This library was designed in such a way that we can easily add a "create" method in the next task, since our Mailchimp object is instantiated with a user record. It will leverage much of what was written during this update task.

![cat-mill](https://user-images.githubusercontent.com/12893/37854932-f7390470-2eba-11e8-8524-c2ffc9ece56f.gif)
