### PR TITLE
add error logging when mailchimp update fails

### DIFF
--- a/lib/mailchimp.rb
+++ b/lib/mailchimp.rb
@@ -70,7 +70,7 @@ module BeyondZ
       
       # if still not found, make a note
       if @mailchimp_record.nil?
-        
+        error("Mailchimp e-mail record was not found")
       end
       
       @mailchimp_record

--- a/lib/mailchimp.rb
+++ b/lib/mailchimp.rb
@@ -68,6 +68,11 @@ module BeyondZ
         @mailchimp_record = record_via_email(user.email)
       end
       
+      # if still not found, make a note
+      if @mailchimp_record.nil?
+        
+      end
+      
       @mailchimp_record
     end
     
@@ -77,8 +82,12 @@ module BeyondZ
     
     private
     
-    def error message, response
-      Rails.logger.error("#{message}:\n----\n#{response.body}\n----")
+    def error message, response=nil
+      if response && response.methods.include?(:body)
+        message += ":\n----\n#{response.body}\n----"
+      end
+      
+      Rails.logger.error(message)
     end
 
     def hex_digest(email=nil)


### PR DESCRIPTION
This latest update will create error-level rails log records when mailchimp updates fail. This won't create an error in the application, only an error message that should be visible regardless of what log level the application is running at.

The two most likely points of failure are a problem with the call itself at a system level, or mailchimp failing to update for some reason (can't find original e-mail, doesn't like the new e-mail, etc). These cases are covered.

![try-again](https://user-images.githubusercontent.com/12893/38203542-2d04bd40-3665-11e8-8b8f-84bcb14fca30.gif)
