### PR TITLE
Set Mailchimp User Region for University Partners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM ruby:2.2.3
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev postgresql-client vim
+
+RUN apt-get update -yqq && apt-get install -y build-essential libpq-dev postgresql-client vim
+
 RUN mkdir /app
 WORKDIR /app
-ADD Gemfile /app/Gemfile
-ADD Gemfile.lock /app/Gemfile.lock
+
+COPY Gemfile* /app/
 RUN bundle install
 
 # Do this after bundle install b/c if we do it before then changing any files 
 # causes bundle install to be invalidated and run again on the next build
-ADD . /app
+COPY . /app
 
+CMD ["foreman", "start"]

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec rails server -p $PORT
+web: bundle exec rails server -p $PORT -b 0.0.0.0
 worker: rake jobs:work
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,17 +1,17 @@
 # PRODUCTION and STAGING aren't required as this file is automatically created in those environments.
 
-development:
+default: &default
   adapter: postgresql
   encoding: unicode
-  database: beyondz-platform_development
+  host: database
   pool: 5
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
 
+development:
+  <<: *default
+  database: beyondz-platform_development
+
 test:
-  adapter: postgresql
-  encoding: unicode
+  <<: *default
   database: beyondz-platform_test
-  pool: 5
-  username: <%= ENV['DATABASE_USERNAME'] %>
-  password: <%= ENV['DATABASE_PASSWORD'] %>

--- a/lib/mailchimp/interest.rb
+++ b/lib/mailchimp/interest.rb
@@ -66,6 +66,35 @@ module BeyondZ; module Mailchimp
         
         interests
       end
+      
+      def region_for user
+        case user.class.name
+        when 'User'
+          if user.bz_region
+            user.bz_region
+          elsif user.university_name
+            if region = region_by_university(user.university_name)
+              region
+            else
+              log "Cannot identify a Region by university name #{user.university_name}"
+              nil
+            end
+          else
+            log "Cannot identify a Region without a user bz_region or university name"
+            nil
+          end
+        when 'Champion'
+          if user.region
+            user.region
+          else
+            log "Cannot identify a Region when champion region is blank"
+            nil
+          end
+        else
+          log "Cannot identify a Region without a User or Champion"
+          nil
+        end
+      end
   
       private
       
@@ -112,35 +141,6 @@ module BeyondZ; module Mailchimp
         end
         
         groups['Location'][:options][region_name]
-      end
-      
-      def region_for user
-        case user.class.name
-        when 'User'
-          if user.bz_region
-            user.bz_region
-          elsif user.university_name
-            if region = region_by_university(user.university_name)
-              region
-            else
-              log "Cannot identify a Region by university name #{user.university_name}"
-              nil
-            end
-          else
-            log "Cannot identify a Region without a user bz_region or university name"
-            nil
-          end
-        when 'Champion'
-          if user.region
-            user.region
-          else
-            log "Cannot identify a Region when champion region is blank"
-            nil
-          end
-        else
-          log "Cannot identify a Region without a User or Champion"
-          nil
-        end
       end
       
       def semester_interest_for user

--- a/lib/mailchimp/interest.rb
+++ b/lib/mailchimp/interest.rb
@@ -7,6 +7,7 @@ module BeyondZ; module Mailchimp
     
     KEY = Rails.application.secrets.mailchimp_key
     LIST_ID = Rails.application.secrets.mailchimp_list_id
+    PRODUCTION_LIST_ID = Rails.application.secrets.production_mailchimp_list_id
     
     class << self
       def groups
@@ -17,12 +18,10 @@ module BeyondZ; module Mailchimp
       end
       
       def sync_from_production
-        production_list_id = Rails.application.secrets.mailchimp_production_list_id
-        
         # return if we are already in production
-        return false if production_list_id == LIST_ID
+        return false if in_production?
         
-        production_groups = get_groups(production_list_id)
+        production_groups = get_groups(PRODUCTION_LIST_ID)
         local_groups = get_groups(LIST_ID)
         
         production_groups.each do |group_name, values|
@@ -231,6 +230,10 @@ module BeyondZ; module Mailchimp
       
       def log message
         Rails.logger.info("MAILCHIMP: #{message}")
+      end
+      
+      def in_production?
+        PRODUCTION_LIST_ID.nil? || PRODUCTION_LIST_ID == LIST_ID
       end
 
       def get uri

--- a/lib/mailchimp/interest.rb
+++ b/lib/mailchimp/interest.rb
@@ -98,32 +98,7 @@ module BeyondZ; module Mailchimp
       end
       
       def location_interest_for user
-        region = case user.class.name
-        when 'User'
-          if user.bz_region
-            user.bz_region
-          elsif user.university_name
-            if region = region_by_university(user.university_name)
-              region
-            else
-              log "Cannot identify a Location interest by university name #{user.university_name}"
-              nil
-            end
-          else
-            log "Cannot identify a Location interest without a user bz_region or university name"
-            nil
-          end
-        when 'Champion'
-          if user.region
-            user.region
-          else
-            log "Cannot identify a Location interest when champion region is blank"
-            nil
-          end
-        else
-          log "Cannot identify a Location interest without a User or Champion"
-          nil
-        end
+        region = region_for user
         
         region_name = case region
         when /chicago/i
@@ -137,6 +112,35 @@ module BeyondZ; module Mailchimp
         end
         
         groups['Location'][:options][region_name]
+      end
+      
+      def region_for user
+        case user.class.name
+        when 'User'
+          if user.bz_region
+            user.bz_region
+          elsif user.university_name
+            if region = region_by_university(user.university_name)
+              region
+            else
+              log "Cannot identify a Region by university name #{user.university_name}"
+              nil
+            end
+          else
+            log "Cannot identify a Region without a user bz_region or university name"
+            nil
+          end
+        when 'Champion'
+          if user.region
+            user.region
+          else
+            log "Cannot identify a Region when champion region is blank"
+            nil
+          end
+        else
+          log "Cannot identify a Region without a User or Champion"
+          nil
+        end
       end
       
       def semester_interest_for user

--- a/lib/mailchimp/user.rb
+++ b/lib/mailchimp/user.rb
@@ -111,7 +111,9 @@ module BeyondZ
           }
         }
         
-        attribs[:merge_fields][:REGION] = user.bz_region if user.bz_region
+        region = BeyondZ::Mailchimp::Interest.region_for(user)
+        attribs[:merge_fields][:REGION] = region if region
+
         attribs[:merge_fields][:SFID] = user.salesforce_id if user.salesforce_id
         
         attribs


### PR DESCRIPTION
University partners' regions are denoted differently from the rest of users. The bz_region attribute isn't set directly, so the user's region wasn't being set in mailchimp. We can derive the region from the university_name attribute, however. In fact, we're already doing that for determining what mailchimp interest groups a user belongs to, so now we're using this same approach to set the MC user region.

It's my understanding that nobody is using any of the docker setup in the app. In order to make coding easier for this fix, I rolled in the docker changes that I'm using locally. Please let me know if this causes anyone problems.

I'm attaching a file with my actual walkthrough of testing this fix, so testing can be easily recreated.

[Mailchimp Testing - University Partner- Bay Area.pdf](https://github.com/beyond-z/beyondz-platform/files/1940358/Mailchimp.Testing.-.University.Partner-.Bay.Area.pdf)
