### PR TITLE
Enable Mailchimp Creation for Volunteers and Champions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM ruby:2.2.3
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev postgresql-client vim
+
+RUN apt-get update -yqq && apt-get install -y build-essential libpq-dev postgresql-client vim
+
 RUN mkdir /app
 WORKDIR /app
-ADD Gemfile /app/Gemfile
-ADD Gemfile.lock /app/Gemfile.lock
+
+COPY Gemfile* /app/
 RUN bundle install
 
 # Do this after bundle install b/c if we do it before then changing any files 
 # causes bundle install to be invalidated and run again on the next build
-ADD . /app
+COPY . /app
 
+CMD ["foreman", "start"]

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec rails server -p $PORT
+web: bundle exec rails server -p $PORT -b 0.0.0.0
 worker: rake jobs:work
 

--- a/app/controllers/calendly_controller.rb
+++ b/app/controllers/calendly_controller.rb
@@ -119,11 +119,13 @@ class CalendlyController < ApplicationController
           current_user.salesforce_id = existing_salesforce_id
           current_user.skip_confirmation!
           current_user.save!
-
+          
           cm = current_user.auto_add_to_salesforce_campaign('Confirmed', selected_timeslot)
           if cm.nil?
             logger.debug "######## Failed to create Campaign Member for #{current_user.inspect}.  Dunno why though."
           end
+
+          current_user.create_mailchimp
 
         elsif event_type == 'invitee.canceled'
           current_user = User.find_by_email(email)

--- a/app/controllers/champions_controller.rb
+++ b/app/controllers/champions_controller.rb
@@ -391,6 +391,7 @@ class ChampionsController < ApplicationController
     n.save
 
     n.create_on_salesforce
+    n.create_mailchimp
 
     if was_new
       ChampionsMailer.new_champion(n).deliver

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,17 +1,17 @@
 # PRODUCTION and STAGING aren't required as this file is automatically created in those environments.
 
-development:
+default: &default
   adapter: postgresql
   encoding: unicode
-  database: beyondz-platform_development
+  host: database
   pool: 5
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
 
+development:
+  <<: *default
+  database: beyondz-platform_development
+
 test:
-  adapter: postgresql
-  encoding: unicode
+  <<: *default
   database: beyondz-platform_test
-  pool: 5
-  username: <%= ENV['DATABASE_USERNAME'] %>
-  password: <%= ENV['DATABASE_PASSWORD'] %>

--- a/lib/mailchimp/interest.rb
+++ b/lib/mailchimp/interest.rb
@@ -66,6 +66,35 @@ module BeyondZ; module Mailchimp
         
         interests
       end
+      
+      def region_for user
+        case user.class.name
+        when 'User'
+          if user.bz_region
+            user.bz_region
+          elsif user.university_name
+            if region = region_by_university(user.university_name)
+              region
+            else
+              log "Cannot identify a Region by university name #{user.university_name}"
+              nil
+            end
+          else
+            log "Cannot identify a Region without a user bz_region or university name"
+            nil
+          end
+        when 'Champion'
+          if user.region
+            user.region
+          else
+            log "Cannot identify a Region when champion region is blank"
+            nil
+          end
+        else
+          log "Cannot identify a Region without a User or Champion"
+          nil
+        end
+      end
   
       private
       
@@ -112,35 +141,6 @@ module BeyondZ; module Mailchimp
         end
         
         groups['Location'][:options][region_name]
-      end
-      
-      def region_for user
-        case user.class.name
-        when 'User'
-          if user.bz_region
-            user.bz_region
-          elsif user.university_name
-            if region = region_by_university(user.university_name)
-              region
-            else
-              log "Cannot identify a Region by university name #{user.university_name}"
-              nil
-            end
-          else
-            log "Cannot identify a Region without a user bz_region or university name"
-            nil
-          end
-        when 'Champion'
-          if user.region
-            user.region
-          else
-            log "Cannot identify a Region when champion region is blank"
-            nil
-          end
-        else
-          log "Cannot identify a Region without a User or Champion"
-          nil
-        end
       end
       
       def semester_interest_for user

--- a/lib/mailchimp/interest.rb
+++ b/lib/mailchimp/interest.rb
@@ -7,6 +7,7 @@ module BeyondZ; module Mailchimp
     
     KEY = Rails.application.secrets.mailchimp_key
     LIST_ID = Rails.application.secrets.mailchimp_list_id
+    PRODUCTION_LIST_ID = Rails.application.secrets.production_mailchimp_list_id
     
     class << self
       def groups
@@ -17,12 +18,10 @@ module BeyondZ; module Mailchimp
       end
       
       def sync_from_production
-        production_list_id = Rails.application.secrets.mailchimp_production_list_id
-        
         # return if we are already in production
-        return false if production_list_id == LIST_ID
+        return false if in_production?
         
-        production_groups = get_groups(production_list_id)
+        production_groups = get_groups(PRODUCTION_LIST_ID)
         local_groups = get_groups(LIST_ID)
         
         production_groups.each do |group_name, values|
@@ -231,6 +230,10 @@ module BeyondZ; module Mailchimp
       
       def log message
         Rails.logger.info("MAILCHIMP: #{message}")
+      end
+      
+      def in_production?
+        PRODUCTION_LIST_ID.nil? || PRODUCTION_LIST_ID == LIST_ID
       end
 
       def get uri

--- a/lib/mailchimp/interest.rb
+++ b/lib/mailchimp/interest.rb
@@ -98,32 +98,7 @@ module BeyondZ; module Mailchimp
       end
       
       def location_interest_for user
-        region = case user.class.name
-        when 'User'
-          if user.bz_region
-            user.bz_region
-          elsif user.university_name
-            if region = region_by_university(user.university_name)
-              region
-            else
-              log "Cannot identify a Location interest by university name #{user.university_name}"
-              nil
-            end
-          else
-            log "Cannot identify a Location interest without a user bz_region or university name"
-            nil
-          end
-        when 'Champion'
-          if user.region
-            user.region
-          else
-            log "Cannot identify a Location interest when champion region is blank"
-            nil
-          end
-        else
-          log "Cannot identify a Location interest without a User or Champion"
-          nil
-        end
+        region = region_for user
         
         region_name = case region
         when /chicago/i
@@ -137,6 +112,35 @@ module BeyondZ; module Mailchimp
         end
         
         groups['Location'][:options][region_name]
+      end
+      
+      def region_for user
+        case user.class.name
+        when 'User'
+          if user.bz_region
+            user.bz_region
+          elsif user.university_name
+            if region = region_by_university(user.university_name)
+              region
+            else
+              log "Cannot identify a Region by university name #{user.university_name}"
+              nil
+            end
+          else
+            log "Cannot identify a Region without a user bz_region or university name"
+            nil
+          end
+        when 'Champion'
+          if user.region
+            user.region
+          else
+            log "Cannot identify a Region when champion region is blank"
+            nil
+          end
+        else
+          log "Cannot identify a Region without a User or Champion"
+          nil
+        end
       end
       
       def semester_interest_for user

--- a/lib/mailchimp/interest.rb
+++ b/lib/mailchimp/interest.rb
@@ -67,7 +67,7 @@ module BeyondZ; module Mailchimp
         interests
       end
       
-      def region_for user
+      def region_for user, verbose=true
         case user.class.name
         when 'User'
           if user.bz_region
@@ -76,24 +76,28 @@ module BeyondZ; module Mailchimp
             if region = region_by_university(user.university_name)
               region
             else
-              log "Cannot identify a Region by university name #{user.university_name}"
+              log "Cannot identify a Region by university name #{user.university_name}" if verbose
               nil
             end
           else
-            log "Cannot identify a Region without a user bz_region or university name"
+            log "Cannot identify a Region without a user bz_region or university name" if verbose
             nil
           end
         when 'Champion'
           if user.region
             user.region
           else
-            log "Cannot identify a Region when champion region is blank"
+            log "Cannot identify a Region when champion region is blank" if verbose
             nil
           end
         else
-          log "Cannot identify a Region without a User or Champion"
+          log "Cannot identify a Region without a User or Champion" if verbose
           nil
         end
+      end
+      
+      def interests_by_name interest_ids
+        interest_ids.map{|interest_id| interests_by_id[interest_id]}
       end
   
       private
@@ -220,6 +224,20 @@ module BeyondZ; module Mailchimp
         end
 
         groups
+      end
+      
+      def interests_by_id
+        return @interests_by_id if defined?(@interests_by_id)
+        
+        @interests_by_id = {}
+        
+        get_groups(LIST_ID).each do |category_name, hash|
+          hash[:options].each do |interest_name, interest_id|
+            @interests_by_id[interest_id] = "#{category_name} - #{interest_name}"
+          end
+        end
+        
+        @interests_by_id
       end
     
       def error message, response=nil

--- a/lib/mailchimp/user.rb
+++ b/lib/mailchimp/user.rb
@@ -111,7 +111,9 @@ module BeyondZ
           }
         }
         
-        attribs[:merge_fields][:REGION] = user.bz_region if user.bz_region
+        region = BeyondZ::Mailchimp::Interest.region_for(user)
+        attribs[:merge_fields][:REGION] = region if region
+
         attribs[:merge_fields][:SFID] = user.salesforce_id if user.salesforce_id
         
         attribs

--- a/lib/salesforce.rb
+++ b/lib/salesforce.rb
@@ -65,8 +65,13 @@ module BeyondZ
       # an old client between server restarts - this will avoid the session
       # expired problem as we reauthorize and fix the global too.
       Databasedotcom::Sobject::Sobject.client = client
-
+      
       client
+    end
+    
+    def client
+      return @client if defined?(@client)
+      @client = get_client
     end
 
     def authenticate(client)
@@ -97,20 +102,26 @@ module BeyondZ
       nil
     end
     
+    def record_for_contact entity
+      client.materialize('Contact')
+      SFDC_Models::Contact.query("Id = '#{entity.salesforce_id}'").first
+    end
+    
     # entity can be a user or champion, at the moment.
     def campaign_for_contact entity
       entity.ensure_salesforce_id
       return if entity.salesforce_id.nil?
       
-      client = get_client
-      
-      client.materialize('CampaignMember')
-      campaign_member = SFDC_Models::CampaignMember.query("ContactId = '#{entity.salesforce_id}'").first
-      
+      campaign_member = campaign_member_for_contact(entity)
       return nil if campaign_member.nil?
       
       client.materialize('Campaign')
       SFDC_Models::Campaign.find(campaign_member.CampaignId)
+    end
+    
+    def campaign_member_for_contact entity
+      client.materialize('CampaignMember')
+      SFDC_Models::CampaignMember.query("ContactId = '#{entity.salesforce_id}'").first
     end
 
     # Returns the Salesforce ID of the contact if they exist or nil if not

--- a/lib/server_sync.rb
+++ b/lib/server_sync.rb
@@ -1,0 +1,141 @@
+require 'salesforce'
+require 'mailchimp/user'
+require 'mailchimp/interest'
+
+class ServerSync
+  attr_reader :subject, :salesforce
+  
+  def initialize user_or_champion
+    @subject = user_or_champion
+    @salesforce = BeyondZ::Salesforce.new
+    @success = true
+  end
+  
+  def verify
+    puts "\nProposed mailchimp groups, please verify that these are what we expect:\n  - #{local_interests.join("\n  - ")}\n\n"
+    
+    puts "Do we have a valid mailchimp record? #{boolean(valid_mailchimp_record?)}\n\n"
+    
+    if valid_mailchimp_record?
+      puts "Verifying that the mailchimp record matches what we expect:"
+
+      puts "  - salesforce id? #{boolean(mailchimp_salesforce_id_matches?)}"
+      puts "  - email? #{boolean(mailchimp_email_matches?)}"
+      puts "  - name? #{boolean(mailchimp_name_matches?)}"
+      puts "  - region? #{boolean(mailchimp_region_matches?)}"
+      puts "  - mailchimp groups? #{boolean(mailchimp_groups_match?)}"
+      puts
+    end
+
+    puts "Do we have a valid salesforce record? #{boolean(salesforce_id_matches?)}\n\n"
+    
+    if salesforce_id_matches?
+      puts "Verifying that the salesforce record matches what we expect:"
+      puts "  - email? #{boolean(salesforce_email_matches?)}"
+      puts "  - name? #{boolean(salesforce_name_matches?)}"
+      
+      if subject.program_semester
+        puts "  - program semester? #{boolean(salesforce_program_semester_matches?)}"
+      end
+    end
+    
+    puts "\nDid all tests pass? #{boolean(@success)}"
+    
+    @success
+  end
+  
+  def salesforce_id_matches?
+    subject.salesforce_id == salesforce_contact_id
+  end
+  
+  def salesforce_email_matches?
+    subject.email == salesforce_user.Email
+  end
+  
+  def salesforce_name_matches?
+    subject.first_name == salesforce_user.FirstName &&
+    subject.last_name  == salesforce_user.LastName
+  end
+  
+  def salesforce_program_semester_matches?
+    local_interests.include?("Semester - #{subject.program_semester}")
+  end
+  
+  def valid_mailchimp_record?
+    !!mailchimp_user
+  end
+  
+  def mailchimp_salesforce_id_matches?
+    mailchimp_user['merge_fields']['SFID'] == subject.salesforce_id
+  end
+  
+  def mailchimp_email_matches?
+    subject.email == mailchimp_fields[:email]
+  end
+  
+  def mailchimp_name_matches?
+    subject.first_name == mailchimp_fields[:first_name] &&
+    subject.last_name  == mailchimp_fields[:last_name]
+  end
+  
+  def mailchimp_first_name_matches?
+    subject.first_name == mailchimp_fields[:first_name]
+  end
+  
+  def mailchimp_region_matches?
+    BeyondZ::Mailchimp::Interest.region_for(subject) == mailchimp_fields[:region]
+  end
+  
+  def mailchimp_groups_match?
+    local_interests.sort == mailchimp_interests.sort
+  end
+  
+  private
+  
+  def boolean condition
+    result = condition ? 'YES' : 'NO'
+    @success = false unless result
+    
+    result
+  end
+  
+  def salesforce_contact_id
+    return @salesforce_contact_id if defined?(@salesforce_contact_id)
+    @salesforce_contact_id = salesforce.exists_in_salesforce(subject.email)
+  end
+  
+  def salesforce_user
+    return @salesforce_user if defined?(@salesforce_user)
+    @salesforce_user = salesforce.record_for_contact(subject)
+  end
+  
+  def local_interests
+    return @local_interests if defined?(@local_interests)
+    
+    interest_ids = BeyondZ::Mailchimp::Interest.interests_for(subject).select{|k,v| v}.keys
+    @local_interests = BeyondZ::Mailchimp::Interest.interests_by_name(interest_ids)
+  end
+  
+  def mailchimp_interests
+    return @mailchimp_interests if defined?(@mailchimp_interests)
+
+    interest_ids = mailchimp_user['interests'].select{|k,v| v}.keys
+    @mailchimp_interests = BeyondZ::Mailchimp::Interest.interests_by_name(interest_ids)
+  end
+  
+  def mailchimp_user
+    return @mailchimp_user if defined?(@mailchimp_user)
+    @mailchimp_user = BeyondZ::Mailchimp::User.new(subject).mailchimp_record
+  end
+  
+  def mailchimp_fields
+    return @mailchimp_fields if defined?(@mailchimp_fields)
+    
+    @mailchimp_fields = {
+      email: mailchimp_user['email_address'],
+      first_name: mailchimp_user['merge_fields']['FNAME'],
+      last_name: mailchimp_user['merge_fields']['LNAME'],
+      region: mailchimp_user['merge_fields']['REGION'],
+    }
+  end
+end


### PR DESCRIPTION
This PR addresses two asana tasks:

https://app.asana.com/0/11824598806566/641632900631320/f
https://app.asana.com/0/11824598806566/641632900631314/f

Both were needed because mailchimp creation wasn't being called via the standard "new user" flow. The solutions for both were very simple, just calling `create_mailchimp` on the objects at the right time.

The LinkedIn issue/resolution wasn't a result of using the "register with linkedin" button, since that just serves to prepopulate the new champion form they have to submit anyway. So I worked from there, and realized that no new champions were being created in mailchimp.

**BIG  NEWS!**

Salesforce/Mailchimp syncing is now much easier to test, because my testing was so repetitive I decided to roll it into a library. These few lines handle all the heavy lifting:

    require 'server_sync'
    
    user = User.last
    ss = ServerSync.new(user)
    
    ss.verify

If it helps, you can think of yourself as launching the "SS Verify" on a voyage of automated sync verification. I sure do. You'll see this library used in the testing protocols I've attached below. Enjoy!

[Mailchimp Creation via Calendly.pdf](https://github.com/beyond-z/beyondz-platform/files/1947998/Mailchimp.Creation.via.Calendly.pdf)

[Mailchimp Creation for Champion in the Bay Area.pdf](https://github.com/beyond-z/beyondz-platform/files/1947999/Mailchimp.Creation.for.Champion.in.the.Bay.Area.pdf)

<img width="603" alt="ss-verify" src="https://user-images.githubusercontent.com/12893/39260743-069e9dd8-4880-11e8-8aab-b34c761ec9be.png">

