### PR TITLE
Fix database host configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,6 @@
 .env-staging
 .env-dev
 
-# We have two versions, one for use with Docker VMs and one for normal localhost and tests.  Leave the
-# test one that Travis uses in src control but don't report changes in git
-config/database.yml
-
 # These are the secrets used to create the Google API refresh token in the ENV
 client_secret.json
 google_credentials.json

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: database
+  host: <%= ENV['DATABASE_HOST'] %>
   pool: 5
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>

--- a/env.sample
+++ b/env.sample
@@ -7,6 +7,7 @@
 RAILS_SECRET_TOKEN=<secret_token>
 
 # database connection credentials
+DATABASE_HOST=localhost
 DATABASE_USERNAME=beyondz-platform
 DATABASE_PASSWORD=
 


### PR DESCRIPTION
Docker configuration requires a database host other than localhost. I inadvertently made this change thinking database.yml was git-ignored, but it isn't. I've updated it to rely on a DATABASE_HOST environment variable to give us the flexibility we need in configuration while still including database.yml in the repo.

I also removed database.yml from .gitconfig, since this was misleading. Git doesn't actually ignore a file that's already been checked into the repo, even if you add that filename to .gitignore after the fact.