### PR TITLE
Fix champion not being added to salesforce campaign

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,9 @@ group :development, :test do
   gem 'capybara'
   # Allows starting the rails server with the .env file specifying the ENV variables
   gem 'foreman'
+  
+  gem 'rspec-rails'
+  gem 'webmock'
 end
 
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     databasedotcom (1.3.3)
       activesupport
       json
@@ -95,6 +97,7 @@ GEM
     devise_cas_authenticatable (1.6.0)
       devise (>= 1.2.0)
       rubycas-client (>= 2.2.1)
+    diff-lcs (1.3)
     erubis (2.7.0)
     execjs (2.6.0)
     extlib (0.9.16)
@@ -130,6 +133,7 @@ GEM
       memoist (~> 0.12)
       multi_json (~> 1.11)
       signet (~> 0.6)
+    hashdiff (0.3.7)
     hike (1.2.3)
     httparty (0.13.7)
       json (~> 1.8)
@@ -222,6 +226,23 @@ GEM
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
     retriable (1.4.1)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-rails (3.7.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.3.0, < 3.0)
@@ -234,6 +255,7 @@ GEM
     ruby-progressbar (1.7.5)
     rubycas-client (2.3.9)
       activesupport
+    safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -279,6 +301,10 @@ GEM
     uuidtools (2.1.5)
     warden (1.2.3)
       rack (>= 1.0)
+    webmock (3.3.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -312,6 +338,7 @@ DEPENDENCIES
   rails (= 4.1.11)
   rails_12factor
   rails_layout
+  rspec-rails
   rubocop
   ruby-openid
   sass-rails (~> 4.0.0)
@@ -320,6 +347,7 @@ DEPENDENCIES
   to_xls-rails
   turbolinks
   uglifier (>= 1.3.0)
+  webmock
 
 BUNDLED WITH
    1.10.6

--- a/app/models/champion.rb
+++ b/app/models/champion.rb
@@ -9,28 +9,26 @@ class Champion < ActiveRecord::Base
   validates :industries, presence: true
   validates :studies, presence: true
   validates :linkedin_url, presence: true
+  
+  def salesforce_campaign_id
+    return @salesforce_campaign_id if defined?(@salesforce_campaign_id)
+    
+    mapping = CampaignMapping.find_by(:applicant_type => 'braven_champion')
+    @salesforce_campaign_id = mapping ? mapping.campaign_id : nil
+  end
 
   def create_on_salesforce
-    mapping = CampaignMapping.where(
-      :applicant_type => 'braven_champion'
-    )
-    return if mapping.empty?
-
-    campaign_id = mapping.first.campaign_id
-
-    salesforce_id = nil
-
     salesforce = BeyondZ::Salesforce.new
     client = salesforce.get_client
     client.materialize('Contact') # Added this b/c sometimes when accessing an existing record before the fields below were added, was getting: ArgumentError (No attribute named LinkedIn_URL__c)
-    campaign = salesforce.load_cached_campaign(campaign_id, client)
+    campaign = salesforce.load_cached_campaign(salesforce_campaign_id, client)
     existing_salesforce_id = salesforce.exists_in_salesforce(email)
     was_new = false
 
     if existing_salesforce_id.nil?
       was_new = true
     else
-      update salesforce_id: existing_salesforce_id
+      self.salesforce_id = existing_salesforce_id
       was_new = false
     end
 
@@ -54,7 +52,7 @@ class Champion < ActiveRecord::Base
 
     if was_new
       contact = client.create('Contact', contact)
-      update salesforce_id: contact['Id']
+      self.salesforce_id = contact['Id']
     else
       # commenting because there is some Databasedotcom::SalesForceError (HTTP Method 'PATCH' not allowed. Allowed are HEAD,GET,POST):
       # error here from SF and we don't really need to update it anyway... so just going to skip so signups don't break.
@@ -62,8 +60,8 @@ class Champion < ActiveRecord::Base
     end
 
     cm = {}
-    cm['CampaignId'] = campaign_id
-    cm['ContactId'] = salesforce_id
+    cm['CampaignId'] = salesforce_campaign_id
+    cm['ContactId'] = self.salesforce_id
     cm['Candidate_Status__c'] = 'Confirmed'
 
     begin
@@ -73,6 +71,8 @@ class Champion < ActiveRecord::Base
       Rails.logger.warn(e)
       @already_member = true # to silence rubocop's complaint that I suppressed it
     end
+    
+    save
   end
 
   def name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -447,6 +447,8 @@ class User < ActiveRecord::Base
   end
 
   def salesforce_campaign_id
+    return @salesforce_campaign_id if defined?(@salesforce_campaign_id)
+    
     mapping = nil
     # For Event Volunteers, they may have been a Fellow or a Coach in the past and thus have their university_name set,
     # however, we don't use university_name when looking up the Campaign for that region, so the mapping is not found.
@@ -471,7 +473,7 @@ class User < ActiveRecord::Base
       end
     end
 
-    mapping.first.campaign_id
+    @salesforce_campaign_id = mapping.first.campaign_id
   end
 
   # The BZ Region that this user is mapped to given their Calendar Email and Application Type


### PR DESCRIPTION
There appears to have been a flaw in the salesforce_id saving during champion creation that allowed the id to be saved properly, but not passed to Salesforce when attempting to add the champion to the correct campaign. This has been fixed, and the ServerSync verifier has been updated to also check that a user/champion is added to the SF campaign as expected.

Here's my testing log:

[Mailchimp Creation for Champion in the Newark Area.pdf](https://github.com/beyond-z/beyondz-platform/files/1968356/Mailchimp.Creation.for.Champion.in.the.Newark.Area.pdf)
