### PR TITLE
Fix fellow salesforce region

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,9 @@ group :development, :test do
   gem 'capybara'
   # Allows starting the rails server with the .env file specifying the ENV variables
   gem 'foreman'
+  
+  gem 'rspec-rails'
+  gem 'webmock'
 end
 
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     databasedotcom (1.3.3)
       activesupport
       json
@@ -95,6 +97,7 @@ GEM
     devise_cas_authenticatable (1.6.0)
       devise (>= 1.2.0)
       rubycas-client (>= 2.2.1)
+    diff-lcs (1.3)
     erubis (2.7.0)
     execjs (2.6.0)
     extlib (0.9.16)
@@ -130,6 +133,7 @@ GEM
       memoist (~> 0.12)
       multi_json (~> 1.11)
       signet (~> 0.6)
+    hashdiff (0.3.7)
     hike (1.2.3)
     httparty (0.13.7)
       json (~> 1.8)
@@ -222,6 +226,23 @@ GEM
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
     retriable (1.4.1)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-rails (3.7.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.3.0, < 3.0)
@@ -234,6 +255,7 @@ GEM
     ruby-progressbar (1.7.5)
     rubycas-client (2.3.9)
       activesupport
+    safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -279,6 +301,10 @@ GEM
     uuidtools (2.1.5)
     warden (1.2.3)
       rack (>= 1.0)
+    webmock (3.3.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -312,6 +338,7 @@ DEPENDENCIES
   rails (= 4.1.11)
   rails_12factor
   rails_layout
+  rspec-rails
   rubocop
   ruby-openid
   sass-rails (~> 4.0.0)
@@ -320,6 +347,7 @@ DEPENDENCIES
   to_xls-rails
   turbolinks
   uglifier (>= 1.3.0)
+  webmock
 
 BUNDLED WITH
    1.10.6

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -427,7 +427,7 @@ class UsersController < ApplicationController
     user[:university_name] = params[:undergrad_university_name] if user[:university_name] == 'other'
 
     user[:phone] = user[:phone].gsub(/[^0-9]/, '') unless user[:phone].blank?
-
+    
     if !user[:applicant_type].nil?
       # We don't create a user now for Event Volunteers.  Instead, we send them to calendly and
       # when they signup for an event, that calls into the calendly_controller to create a new
@@ -449,6 +449,7 @@ class UsersController < ApplicationController
       user[:applicant_type] = 'leadership_coach' if user[:applicant_type] == 'volunteer'
       user[:applicant_type] = 'event_volunteer' if user[:applicant_type] == 'temp_volunteer'
       @new_user = User.new(user)
+      
       unless user[:applicant_type] == 'undergrad_student' || user[:applicant_type] == 'leadership_coach' || user[:applicant_type] == 'event_volunteer'
         # Partners, employers, and others are reached out to manually instead of confirming
         # their account. We immediate make on salesforce and don't require confirmation so

--- a/app/models/champion.rb
+++ b/app/models/champion.rb
@@ -9,28 +9,26 @@ class Champion < ActiveRecord::Base
   validates :industries, presence: true
   validates :studies, presence: true
   validates :linkedin_url, presence: true
+  
+  def salesforce_campaign_id
+    return @salesforce_campaign_id if defined?(@salesforce_campaign_id)
+    
+    mapping = CampaignMapping.find_by(:applicant_type => 'braven_champion')
+    @salesforce_campaign_id = mapping ? mapping.campaign_id : nil
+  end
 
   def create_on_salesforce
-    mapping = CampaignMapping.where(
-      :applicant_type => 'braven_champion'
-    )
-    return if mapping.empty?
-
-    campaign_id = mapping.first.campaign_id
-
-    salesforce_id = nil
-
     salesforce = BeyondZ::Salesforce.new
     client = salesforce.get_client
     client.materialize('Contact') # Added this b/c sometimes when accessing an existing record before the fields below were added, was getting: ArgumentError (No attribute named LinkedIn_URL__c)
-    campaign = salesforce.load_cached_campaign(campaign_id, client)
+    campaign = salesforce.load_cached_campaign(salesforce_campaign_id, client)
     existing_salesforce_id = salesforce.exists_in_salesforce(email)
     was_new = false
 
     if existing_salesforce_id.nil?
       was_new = true
     else
-      update salesforce_id: existing_salesforce_id
+      self.salesforce_id = existing_salesforce_id
       was_new = false
     end
 
@@ -54,7 +52,7 @@ class Champion < ActiveRecord::Base
 
     if was_new
       contact = client.create('Contact', contact)
-      update salesforce_id: contact['Id']
+      self.salesforce_id = contact['Id']
     else
       # commenting because there is some Databasedotcom::SalesForceError (HTTP Method 'PATCH' not allowed. Allowed are HEAD,GET,POST):
       # error here from SF and we don't really need to update it anyway... so just going to skip so signups don't break.
@@ -62,8 +60,8 @@ class Champion < ActiveRecord::Base
     end
 
     cm = {}
-    cm['CampaignId'] = campaign_id
-    cm['ContactId'] = salesforce_id
+    cm['CampaignId'] = salesforce_campaign_id
+    cm['ContactId'] = self.salesforce_id
     cm['Candidate_Status__c'] = 'Confirmed'
 
     begin
@@ -73,6 +71,8 @@ class Champion < ActiveRecord::Base
       Rails.logger.warn(e)
       @already_member = true # to silence rubocop's complaint that I suppressed it
     end
+    
+    save
   end
 
   def name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -447,6 +447,8 @@ class User < ActiveRecord::Base
   end
 
   def salesforce_campaign_id
+    return @salesforce_campaign_id if defined?(@salesforce_campaign_id)
+    
     mapping = nil
     # For Event Volunteers, they may have been a Fellow or a Coach in the past and thus have their university_name set,
     # however, we don't use university_name when looking up the Campaign for that region, so the mapping is not found.
@@ -471,7 +473,7 @@ class User < ActiveRecord::Base
       end
     end
 
-    mapping.first.campaign_id
+    @salesforce_campaign_id = mapping.first.campaign_id
   end
 
   # The BZ Region that this user is mapped to given their Calendar Email and Application Type

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -260,7 +260,7 @@ class User < ActiveRecord::Base
     # with the BZ Region set, that's when their region is updated.
     #
     # BZ_Region is required, so if it's not set, default them to National
-    contact['BZ_Region__c'] = (bz_region.blank? || bz_region.strip == 'Other:') ? 'National' : bz_region
+    contact['BZ_Region__c'] = (region.blank? || region.strip == 'Other:') ? 'National' : region
 
     lead_created = false
 
@@ -421,6 +421,16 @@ class User < ActiveRecord::Base
     end
   rescue Databasedotcom::SalesForceError => e
     logger.warn "###### Caught Databasedotcom::SalesForceError #{e.inspect} -- Failed to update CampaignMember and record a Task of the cancellation for #{first_name} #{last_name} - #{selected_timeslot}"
+  end
+  
+  def region
+    region_by_university = Hash.new(nil).merge({
+      'National Louis University' => 'Chicago',
+      'San Jose State University' => 'San Francisco Bay Area, San Jose',
+      'Rutgers University - Newark' => 'Newark, NJ'
+    })
+    
+    bz_region || region_by_university[university_name]
   end
 
   def salesforce_applicant_type

--- a/lib/mailchimp/interest.rb
+++ b/lib/mailchimp/interest.rb
@@ -67,35 +67,6 @@ module BeyondZ; module Mailchimp
         interests
       end
       
-      def region_for user, verbose=true
-        case user.class.name
-        when 'User'
-          if user.bz_region
-            user.bz_region
-          elsif user.university_name
-            if region = region_by_university(user.university_name)
-              region
-            else
-              log "Cannot identify a Region by university name #{user.university_name}" if verbose
-              nil
-            end
-          else
-            log "Cannot identify a Region without a user bz_region or university name" if verbose
-            nil
-          end
-        when 'Champion'
-          if user.region
-            user.region
-          else
-            log "Cannot identify a Region when champion region is blank" if verbose
-            nil
-          end
-        else
-          log "Cannot identify a Region without a User or Champion" if verbose
-          nil
-        end
-      end
-      
       def interests_by_name interest_ids
         interest_ids.map{|interest_id| interests_by_id[interest_id]}
       end
@@ -131,9 +102,7 @@ module BeyondZ; module Mailchimp
       end
       
       def location_interest_for user
-        region = region_for user
-        
-        region_name = case region
+        region_name = case user.region
         when /chicago/i
           'NLU'
         when /san\s+francisco/i
@@ -160,14 +129,6 @@ module BeyondZ; module Mailchimp
         end
         
         ids
-      end
-      
-      def region_by_university name 
-        {
-          'National Louis University' => 'Chicago',
-          'San Jose State University' => 'San Francisco Bay Area, San Jose',
-          'Rutgers University - Newark' => 'Newark, NJ'
-        }[name]
       end
       
       def create_group group_name

--- a/lib/mailchimp/user.rb
+++ b/lib/mailchimp/user.rb
@@ -111,9 +111,7 @@ module BeyondZ
           }
         }
         
-        region = BeyondZ::Mailchimp::Interest.region_for(user)
-        attribs[:merge_fields][:REGION] = region if region
-
+        attribs[:merge_fields][:REGION] = user.region if user.region
         attribs[:merge_fields][:SFID] = user.salesforce_id if user.salesforce_id
         
         attribs

--- a/lib/server_sync.rb
+++ b/lib/server_sync.rb
@@ -12,35 +12,41 @@ class ServerSync
   end
   
   def verify
-    puts "\nProposed mailchimp groups, please verify that these are what we expect:\n  - #{local_interests.join("\n  - ")}\n\n"
+    outputs = []
     
-    puts "Do we have a valid mailchimp record? #{boolean(valid_mailchimp_record?)}\n\n"
+    outputs << "\nProposed mailchimp groups, please verify that these are what we expect:\n  - #{local_interests.join("\n  - ")}\n\n"
+    
+    outputs << "Do we have a valid mailchimp record? #{boolean(valid_mailchimp_record?)}\n\n"
     
     if valid_mailchimp_record?
-      puts "Verifying that the mailchimp record matches what we expect:"
+      outputs << "Verifying that the mailchimp record matches what we expect:"
 
-      puts "  - salesforce id? #{boolean(mailchimp_salesforce_id_matches?)}"
-      puts "  - email? #{boolean(mailchimp_email_matches?)}"
-      puts "  - name? #{boolean(mailchimp_name_matches?)}"
-      puts "  - region? #{boolean(mailchimp_region_matches?)}"
-      puts "  - mailchimp groups? #{boolean(mailchimp_groups_match?)}"
-      puts
+      outputs << "  - salesforce id? #{boolean(mailchimp_salesforce_id_matches?)}"
+      outputs << "  - email? #{boolean(mailchimp_email_matches?)}"
+      outputs << "  - name? #{boolean(mailchimp_name_matches?)}"
+      outputs << "  - region? #{boolean(mailchimp_region_matches?)}"
+      outputs << "  - mailchimp groups? #{boolean(mailchimp_groups_match?)}"
     end
 
-    puts "Do we have a valid salesforce record? #{boolean(salesforce_id_matches?)}\n\n"
+    outputs << "\nDo we have a valid salesforce record? #{boolean(salesforce_id_matches?)}\n\n"
     
     if salesforce_id_matches?
-      puts "Verifying that the salesforce record matches what we expect:"
-      puts "  - email? #{boolean(salesforce_email_matches?)}"
-      puts "  - name? #{boolean(salesforce_name_matches?)}"
-      puts "  - campaign_id(#{subject.salesforce_campaign_id})? #{boolean(salesforce_campaign_id_matches?)}"
+      outputs << "Verifying that the salesforce record matches what we expect:"
+
+      outputs << "  - email? #{boolean(salesforce_email_matches?)}"
+      outputs << "  - name? #{boolean(salesforce_name_matches?)}"
+      outputs << "  - preferred region? #{boolean(salesforce_preferred_region_matches?)}"
+      outputs << "  - all regions include region? #{boolean(salesforce_all_regions_matches?)}"
+      outputs << "  - campaign_id(#{subject.salesforce_campaign_id})? #{boolean(salesforce_campaign_id_matches?)}"
       
       if subject.program_semester
-        puts "  - program semester? #{boolean(salesforce_program_semester_matches?)}"
+        outputs << "  - program semester? #{boolean(salesforce_program_semester_matches?)}"
       end
     end
     
-    puts "\nDid all tests pass? #{boolean(@success)}"
+    outputs << "\nDid all tests pass? #{boolean(@success)}"
+    
+    outputs.each{|output| puts output}
     
     @success
   end
@@ -70,6 +76,14 @@ class ServerSync
     salesforce_campaign_member.CampaignId[0,shortest_campaign_id_length] == subject.salesforce_campaign_id[0,shortest_campaign_id_length]
   end
   
+  def salesforce_preferred_region_matches?
+    salesforce_user && salesforce_user.BZ_Region__c == subject.region
+  end
+  
+  def salesforce_all_regions_matches?
+    salesforce_user && salesforce_user.All_BZ_Regions__c.include?(subject.region)
+  end
+  
   def valid_mailchimp_record?
     !!mailchimp_user
   end
@@ -92,7 +106,7 @@ class ServerSync
   end
   
   def mailchimp_region_matches?
-    BeyondZ::Mailchimp::Interest.region_for(subject) == mailchimp_fields[:region]
+    subject.region == mailchimp_fields[:region]
   end
   
   def mailchimp_groups_match?


### PR DESCRIPTION
Asana task: https://app.asana.com/0/11824598806566/654248652194426/f

We weren't passing the region to salesforce when creating leads for fellows. This is because we pass the bz_region attribute, which is nil for fellows. Fellow region is determined instead by their university affiliation. We're now correctly passing this to salesforce, so that it's properly making its way into the "All BZ Regions" list for the SF contact.

Here is the successful testing log:

[Mailchimp Creation for Fellow at NLU.pdf](https://github.com/beyond-z/beyondz-platform/files/1972567/Mailchimp.Creation.for.Fellow.at.NLU.pdf)