### PR TITLE
Send NEWSLETTER="False" as a required mailchimp merge field

### DIFF
--- a/lib/mailchimp/user.rb
+++ b/lib/mailchimp/user.rb
@@ -107,7 +107,8 @@ module BeyondZ
           interests: BeyondZ::Mailchimp::Interest.interests_for(user),
           merge_fields: {
             FNAME: user.first_name,
-            LNAME: user.last_name
+            LNAME: user.last_name,
+            NEWSLETTER: "False"
           }
         }
         

--- a/lib/server_sync.rb
+++ b/lib/server_sync.rb
@@ -26,6 +26,7 @@ class ServerSync
       outputs << "  - name? #{boolean(mailchimp_name_matches?)}"
       outputs << "  - region? #{boolean(mailchimp_region_matches?)}"
       outputs << "  - mailchimp groups? #{boolean(mailchimp_groups_match?)}"
+      outputs << "  - newsletter options? #{boolean(mailchimp_newsletter_match?)}"
     end
 
     outputs << "\nDo we have a valid salesforce record? #{boolean(salesforce_id_matches?)}\n\n"
@@ -113,6 +114,10 @@ class ServerSync
     local_interests.sort == mailchimp_interests.sort
   end
   
+  def mailchimp_newsletter_match?
+    mailchimp_fields[:newsletter] == 'FALSE'
+  end
+  
   private
   
   def boolean condition
@@ -162,6 +167,7 @@ class ServerSync
       first_name: mailchimp_user['merge_fields']['FNAME'],
       last_name: mailchimp_user['merge_fields']['LNAME'],
       region: mailchimp_user['merge_fields']['REGION'],
+      newsletter: mailchimp_user['merge_fields']['NEWSLETTER'].upcase
     }
   end
 end


### PR DESCRIPTION
This is for asana task: https://app.asana.com/0/11824598806566/661010572667893/f

Mailchimp user creation was failing in production because we didn't have the required merge field NewsletterSubscriber in the dev mailchimp list. I added that, and all other missing fields (required or not) to the dev list so it now matches the production list exactly.

From there, I updated the app to send NEWSLETTER="False" as a merge field for all mailchimp user creation/updates. FYI, this is implemented in prod as a radio button with string options "True" and "False" (rather than actual boolean values) so this is what I mimicked in our dev list.

The ServerSync verifier now also checks that this is set properly as part of its regular testing. Here is my testing log:

[Mailchimp Creation with Newsletter Merge Field.pdf](https://github.com/beyond-z/beyondz-platform/files/1975977/Mailchimp.Creation.with.Newsletter.Merge.Field.pdf)

![automated-testing](https://user-images.githubusercontent.com/12893/39654557-f9996a72-4fba-11e8-8e7a-c08c558537e6.gif)
