### PR TITLE
auto-create mailchimp semester groups

### DIFF
--- a/lib/mailchimp/interest.rb
+++ b/lib/mailchimp/interest.rb
@@ -44,6 +44,8 @@ module BeyondZ; module Mailchimp
             end
           end
         end
+        
+        reset_group_instance_variables
       end
       
       def interests_for user
@@ -118,7 +120,17 @@ module BeyondZ; module Mailchimp
       
       def semester_interest_for user
         return nil if user.program_semester.nil?
-        groups['Semester'][:options][user.program_semester]
+        
+        if semester_interest = groups['Semester'][:options][user.program_semester]
+          semester_interest
+        else
+          semester_id = groups['Semester'][:id]
+          
+          create_group_option(semester_id, user.program_semester)
+          reset_group_instance_variables
+          
+          groups['Semester'][:options][user.program_semester]
+        end
       end
       
       def interest_ids
@@ -209,6 +221,11 @@ module BeyondZ; module Mailchimp
         end
     
         Rails.logger.error("MAILCHIMP: #{message}")
+      end
+      
+      def reset_group_instance_variables
+        remove_instance_variable :@groups if defined?(@groups)
+        remove_instance_variable :@interests_by_id if defined?(@interests_by_id)
       end
       
       def log message


### PR DESCRIPTION
Asana task: https://app.asana.com/0/11824598806566/662280981639350/f

User creation in production resulted in a mailchimp user record without the program semester group being set properly. This is because the group didn't exist yet in mailchimp. Rather than remembering to create future semester groups forever, the app will now create them as needed whenever it sees a semester group that doesn't yet exist on mailchimp.

Here's my testing log:

[Auto-Create Mailchimp Semester Groups.pdf](https://github.com/beyond-z/beyondz-platform/files/1985836/Auto-Create.Mailchimp.Semester.Groups.pdf)

...and like magic, we have auto-generated program semesters on mailchimp!

![fall-2018](https://user-images.githubusercontent.com/12893/39786232-3c9bf4f2-52e5-11e8-9c0b-2e05f7acc5cc.gif)
