### PR TITLE
required, pre-filled phone number because we forgot

### DIFF
--- a/app/controllers/mentor_controller.rb
+++ b/app/controllers/mentor_controller.rb
@@ -176,6 +176,7 @@ class MentorController < ApplicationController
     application.first_name = params[:first_name]
     application.last_name = params[:last_name]
     application.email = params[:email]
+    application.phone = params[:phone]
     application.linkedin_url = params[:linkedin_url]
     application.city = params[:city]
     application.state = params[:state]

--- a/app/views/mentor/mentee_app.html.erb
+++ b/app/views/mentor/mentee_app.html.erb
@@ -74,7 +74,7 @@
             </label>
             <label>
               <span class="required">Phone number:</span>
-              <input class="form-control" required="required" name="phone" type="text" maxlength="255" />
+              <input class="form-control" required="required" name="phone" type="tel" maxlength="255" value="<%=@phone%>" />
             </label>
             <label>
               <span class="required">LinkedIn profile URL:</span>

--- a/app/views/mentor/mentor_app.html.erb
+++ b/app/views/mentor/mentor_app.html.erb
@@ -85,6 +85,10 @@
               <input maxlength="255" class="form-control" required="required" name="email" type="email" value="<%=@email%>" />
             </label>
             <label>
+              <span class="required">Phone number:</span>
+              <input class="form-control" required="required" name="phone" type="tel" maxlength="255" value="<%=@phone%>" />
+            </label>
+            <label>
               <span class="required">LinkedIn profile URL:</span>
               <input maxlength="255" class="form-control" required="required" name="linkedin_url" type="text" />
             </label>

--- a/db/migrate/20190807160657_not_null_mentor_application.rb
+++ b/db/migrate/20190807160657_not_null_mentor_application.rb
@@ -1,0 +1,5 @@
+class NotNullMentorApplication < ActiveRecord::Migration
+  def up
+    change_column_null :mentor_applications, :phone, false, ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190529231135) do
+ActiveRecord::Schema.define(version: 20190807160657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -402,7 +402,7 @@ ActiveRecord::Schema.define(version: 20190529231135) do
     t.string   "linkedin_url"
     t.string   "major"
     t.string   "other_industries"
-    t.string   "phone"
+    t.string   "phone",                               null: false
     t.string   "reference2_email"
     t.string   "reference2_name"
     t.string   "reference2_phone"


### PR DESCRIPTION
Robert and Dennis found some missing phone numbers on SF, this is why. The phone was on the user record, but not the application and it got overwritten. I fixed existing records with a script, and this will fix the others going forward.