### PR TITLE
Add Sentry error tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,3 +116,4 @@ gem 'pg_search'
 
 gem 'exception_notification'
 gem 'newrelic_rpm'
+gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    sentry-raven (2.11.0)
+      faraday (>= 0.7.6, < 1.0)
     signet (0.11.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -341,6 +343,7 @@ DEPENDENCIES
   ruby-openid
   sass-rails (~> 4.0.0)
   sdoc
+  sentry-raven
   therubyracer
   to_xls-rails
   turbolinks


### PR DESCRIPTION
Task: https://app.asana.com/0/1136372351092870/1137743756490017

Summary:

* Add the Sentry gem; needs Heroku env variable `SENTRY_DSN`.