### PR TITLE
For Pro Mentor app, set the max length of various fields to match Salesforce.

### DIFF
--- a/app/views/mentor/mentor_app.html.erb
+++ b/app/views/mentor/mentor_app.html.erb
@@ -74,11 +74,11 @@
             <b>Please enter the following information about yourself:</b>
             <label>
               <span class="required">First Name:</span>
-              <input maxlength="255" class="form-control" required="required" name="first_name" type="text" value="<%=@first_name%>" />
+              <input maxlength="40" class="form-control" required="required" name="first_name" type="text" value="<%=@first_name%>" />
             </label>
             <label>
               <span class="required">Last Name:</span>
-              <input maxlength="255" class="form-control" required="required" name="last_name" type="text" value="<%=@last_name%>" />
+              <input maxlength="80" class="form-control" required="required" name="last_name" type="text" value="<%=@last_name%>" />
             </label>
             <label>
               <span class="required">Email address:</span>
@@ -96,21 +96,21 @@
             <b>Where do you live?</b>
             <label>
               <span class="required">City:</span>
-              <input maxlength="255" class="form-control" required="required" name="city" type="text" value="<%=@city%>" />
+              <input maxlength="40" class="form-control" required="required" name="city" type="text" value="<%=@city%>" />
             </label>
             <label>
               <span class="required">State:</span>
-              <input maxlength="255" class="form-control" required="required" name="state" type="text" value="<%=@state%>" />
+              <input maxlength="80" class="form-control" required="required" name="state" type="text" value="<%=@state%>" />
             </label>
             <br />
             <b>Where do you work?</b>
             <label>
               <span class="required">City:</span>
-              <input maxlength="255" class="form-control" required="required" name="work_city" type="text" />
+              <input maxlength="60" class="form-control" required="required" name="work_city" type="text" />
             </label>
             <label>
               <span class="required">State:</span>
-              <input maxlength="255" class="form-control" required="required" name="work_state" type="text" />
+              <input maxlength="60" class="form-control" required="required" name="work_state" type="text" />
             </label>
           </div>
           <h2>Professional Background</h2>
@@ -126,17 +126,17 @@
             <br />
             <b>If other, please enter here:</b>
             <label>
-              <input maxlength="255" class="form-control" name="major_other" type="text" />
+              <input maxlength="120" class="form-control" name="major_other" type="text" />
             </label>
             <br />
             <b>Please tell us about your current role:</b>
             <label>
               <span class="required">Employer:</span>
-              <input maxlength="255" class="form-control" required="required" name="employer" type="text" />
+              <input maxlength="80" class="form-control" required="required" name="employer" type="text" />
             </label>
             <label>
               <span class="required">Title:</span>
-              <input maxlength="255" class="form-control" required="required" name="title" type="text" />
+              <input maxlength="128" class="form-control" required="required" name="title" type="text" />
             </label>
             <label>
               <span class="required">Industry i.e. if you work in Tech, select "Tech":</span>
@@ -293,7 +293,7 @@
             <b>Please provide the names, email addresses, and phone numbers for two references.</b>
             <label>
               <span class="required">Reference #1 name:</span>
-              <input maxlength="255" class="form-control" required="required" name="reference_name" type="text" />
+              <input maxlength="240" class="form-control" required="required" name="reference_name" type="text" />
             </label>
             <label>
               <span class="required">Reference #1 email address:</span>
@@ -305,7 +305,7 @@
             </label>
             <label>
               <span class="required">Reference #2 name:</span>
-              <input maxlength="255" class="form-control" required="required" name="reference2_name" type="text" />
+              <input maxlength="240" class="form-control" required="required" name="reference2_name" type="text" />
             </label>
             <label>
               <span class="required">Reference #2 email address:</span>


### PR DESCRIPTION
I went through the Contact and Campaign Member fields on Salesforce and
anything of type Text(charlimit) that was less than 255, I updated here
to match. We were getting people failing to submit with stacktraces like
below:

Databasedotcom::SalesForceError (Company: data value too large: ...
   <redacted long sentence about their employment status> ...) (max length=80)):
 app/controllers/mentor_controller.rb:378:in `save_to_salesforce'
 app/controllers/mentor_controller.rb:231:in `save_mentor_app'