### PR TITLE
Change 'Due Dates Export' to do it on background worker and email result

### DIFF
--- a/app/mailers/staff_notifications.rb
+++ b/app/mailers/staff_notifications.rb
@@ -49,6 +49,11 @@ class StaffNotifications < ActionMailer::Base
     mail(to: email, subject: 'Canvas Events spreadsheet', from: 'Braven Website <' + Rails.application.secrets.mailer_from_email + '>')
   end
 
+  def canvas_due_dates_ready(email, data)
+    attachments['get_canvas_due_dates.csv'] = data
+    mail(to: email, subject: 'Due dates spreadsheet', from: 'Braven Website <' + Rails.application.secrets.mailer_from_email + '>')
+  end
+
   def canvas_due_dates_updated(email)
     mail(to: email, subject: 'Due date upload complete')
   end

--- a/app/views/admin/assignments/choose_due_dates_export.erb
+++ b/app/views/admin/assignments/choose_due_dates_export.erb
@@ -1,0 +1,16 @@
+<form method="GET" action="<%= admin_assignments_get_due_dates_path%>">
+  <p>Enter the course ID to download the assignment due dates for.</p>
+  <p>The course ID is the canvas course number. E.g. 71 is the 2019 Fall SJSU Accelerator. If you go to a course in Canvas, you can find this id in the url right after teh courses/ part.</p>
+  <p>Requesting the spreadsheet will cause it to be emailed to you when the data preparation is finished, which can take several minutes.</p>
+  <label>Course ID: 
+    <input type="text" name="course_id" value="71" />
+  </label>
+  <label>Your email address: 
+    <input type="email" name="email" value="tech@bebraven.org" />
+  </label>
+  <br />
+  <input type="submit" value="Request spreadsheet" />
+</form>
+
+<br /><br />
+<p>Afterward, go to <%= link_to "Set Due Dates", admin_set_due_dates_path %> and upload your changes.</p>

--- a/app/views/admin/assignments/get_due_dates.erb
+++ b/app/views/admin/assignments/get_due_dates.erb
@@ -1,0 +1,1 @@
+<p>Check your email in a couple minutes and the spreadsheet should be there.</p>

--- a/app/views/admin/assignments/get_due_dates.html.erb
+++ b/app/views/admin/assignments/get_due_dates.html.erb
@@ -1,9 +1,0 @@
-<p>Select a course to get a spreadsheet of its assignments and due dates.</p>
-
-<%= form_for :course do |f| %>
-  <%= f.select :course_id, options_for_select(@courses) %>
-  <%= submit_tag 'Get Assignments' %>
-<% end %>
-
-<br /><br />
-<p>Afterward, go to <%= link_to "Set Due Dates", admin_set_due_dates_path %> and upload your changes.</p>

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -45,7 +45,7 @@
 
   <li><%= link_to 'Canvas Page View Data', admin_canvas_page_views_path %></li>
 
-  <li><%= link_to 'Due Date Export', admin_get_due_dates_path %></li>
+  <li><%= link_to 'Due Date Export', admin_choose_due_dates_export_path %></li>
   <li><%= link_to 'Due Date Import', admin_set_due_dates_path %></li>
 
   <li><%= link_to 'Events Export', admin_get_events_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,8 +111,8 @@ BeyondzPlatform::Application.routes.draw do
   namespace :admin do
     root "home#index"
 
-    get '/assignments/get_due_dates', to: 'assignments#get_due_dates', as: 'get_due_dates'
-    post '/assignments/get_due_dates', to: 'assignments#download_due_dates', defaults: { format: 'csv' }
+    get '/assignments/choose_due_dates', to: 'assignments#choose_due_dates_export', as: 'choose_due_dates_export'
+    get '/assignments/get_due_dates', to: 'assignments#get_due_dates'
 
     get '/assignments/set_due_dates', to: 'assignments#set_due_dates', as: 'set_due_dates'
     post '/assignments/set_due_dates', to: 'assignments#do_set_due_dates'

--- a/lib/lms.rb
+++ b/lib/lms.rb
@@ -745,6 +745,55 @@ module BeyondZ
       StaffNotifications.canvas_views_ready(email, get_user_data_spreadsheet(course_id)).deliver
     end
 
+    def get_assignment_due_dates_spreadsheet(course_id)
+      assignments = get_assignments(course_id)
+      CSV.generate do |csv|
+        header = []
+        header << 'Assignment ID (do not change)'
+        header << 'Course ID (do not change)'
+        header << 'Name'
+        header << 'Section Name'
+        header << 'Due Date'
+        header << 'Until'
+        header << 'Override ID (do not change, but leave blank for new section)'
+  
+        csv << header
+  
+        assignments.each do |a|
+          exportable = []
+          exportable << a['id']
+          exportable << a['course_id']
+          exportable << a['name']
+          exportable << ''
+          exportable << export_date_translation(a['due_at'])
+          exportable << export_date_translation(a['lock_at'])
+          exportable << ''
+  
+          csv << exportable
+  
+          if a['overrides']
+            a['overrides'].each do |override|
+              exportable = []
+              exportable << a['id']
+              exportable << a['course_id']
+              exportable << a['name']
+              exportable << override['title']
+              exportable << export_date_translation(override['due_at'])
+              exportable << export_date_translation(override['lock_at'])
+              exportable << override['id']
+  
+              csv << exportable
+            end
+          end
+        end
+      end
+    end
+
+    def email_assignment_due_dates_spreadsheet(email, course_id)
+      StaffNotifications.canvas_due_dates_ready(email, get_assignment_due_dates_spreadsheet(course_id)).deliver
+    end
+
+
     def get_events_for_email(email, course_id)
         lms = BeyondZ::LMS.new
 


### PR DESCRIPTION
See: https://app.asana.com/0/1133543009734854/1144390735082009

It was timing out in production b/c Heroku has a 15-30sec timeout for a
response and it's taking longer than that. Follow the pattern that the
rest of these do and have them enter an email, then queue up a delayed
job and email the results.

This is admin only and only one staff member is using this, so it's low
risk. I'm going to skip getting it reviewed b/c it just mimics the other
stuff and it's urgent to get this working.

TESTING:
- I don't have delayed jobs and the mailer setup to run locally, so I
  only tested that the pages are loading and calling the correct methods.
  I'm going to test if it works end-to-end in staging.