### PR TITLE
Trying to fix SSL connection error when hitting Portal API when hosted on Heroku

### DIFF
--- a/lib/lms.rb
+++ b/lib/lms.rb
@@ -948,8 +948,15 @@ module BeyondZ
     #
     # This is a separate method that opens a member @canvas_http so
     # we can reuse the connection across several requests for performance.
+    #
     def open_canvas_http
-      if @canvas_http.nil?
+ 
+    # NOTE: disabling the re-use of connections. When connecting to Heroku hosted
+    # apps over SSL, the first request works but the second fails with:
+    # "OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: tlsv1 alert protocol version"
+    # Leaving this method here in case we figure out how to re-use SSL connections against those servers,
+    # we can likely just fix it here.
+    # if @canvas_http.nil?
         @canvas_http = Net::HTTP.new(Rails.application.secrets.canvas_server, Rails.application.secrets.canvas_port)
         if Rails.application.secrets.canvas_use_ssl
           @canvas_http.use_ssl = true
@@ -957,7 +964,7 @@ module BeyondZ
             @canvas_http.verify_mode = OpenSSL::SSL::VERIFY_NONE # self-signed cert would fail
           end
         end
-      end
+    # end
 
       @canvas_http
     end


### PR DESCRIPTION
For example, when I try and use Create Special Canvas User
to call into the Portal API and create a one-off user, it fails with the following:

```
OpenSSL::SSL::SSLError (SSL_connect returned=1 errno=0 state=error: tlsv1 alert internal error):
lib/lms.rb:346:in `create_user_in_canvas'
lib/lms.rb:402:in `sync_user_logins'
app/controllers/admin/users_controller.rb:361:in `create'
```

Note: this worked before when the Portal was hosted on an AWS EC2 instance running Apache.
It's something about the Heroku router, SSL endpoint stuff.

Through the console, I was banging my head running the same code manually
and it was working. Eventually I figure out that the manual code would fail
with the same error if I ran it again without creating a new Net::HTTP
instance. That was the aha. I'm not 100% sure this is going to work, but I want
to test it out in staging.

Note: I don't really know the underlying issue here, so I'm leaving the code
mostly intact in case we figure that out and need to optimize performance
here.