### PR TITLE
Add rake task to restart dynos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,3 +117,9 @@ gem 'pg_search'
 gem 'exception_notification'
 gem 'newrelic_rpm'
 gem 'sentry-raven'
+
+# Allows us to write rake tasks that can programatticaly run Heroku commands
+# using their API. E.g. create a task to restart a dyno so it can be run
+# in the middle of the night to avoid downtime when users are on the platform
+# See: https://github.com/heroku/platform-api
+gem 'platform-api', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
     exception_notification (4.3.0)
       actionmailer (>= 4.0, < 6)
       activesupport (>= 4.0, < 6)
+    excon (0.72.0)
     execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -133,6 +134,11 @@ GEM
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
     hashdiff (0.3.7)
+    heroics (0.0.25)
+      erubis (~> 2.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
     hike (1.2.3)
     httparty (0.13.7)
       json (~> 1.8)
@@ -162,6 +168,7 @@ GEM
     mimemagic (0.3.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    moneta (1.0.0)
     msworddoc-extractor (0.2.0)
       ruby-ole
     multi_json (1.13.1)
@@ -185,6 +192,9 @@ GEM
       activerecord (>= 3.1)
       activesupport (>= 3.1)
       arel
+    platform-api (2.2.0)
+      heroics (~> 0.0.25)
+      moneta (~> 1.0.0)
     powerpack (0.1.1)
     public_suffix (3.0.3)
     rack (1.5.5)
@@ -335,6 +345,7 @@ DEPENDENCIES
   paperclip
   pg
   pg_search
+  platform-api
   rails (= 4.1.11)
   rails_12factor
   rails_layout

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,7 +1,30 @@
 desc "This task is called by the Heroku scheduler add-on"
+# https://devcenter.heroku.com/articles/scheduler
 
 task :send_reminders => :environment do
   ChampionContact.send_reminders
 end
 
-# https://devcenter.heroku.com/articles/scheduler
+namespace :heroku do
+  namespace :app do
+    require 'platform-api'
+    
+      # Example call: HEROKU_OAUTH_TOKEN=my-token HEROKU_APP_NAME=my-app bundle exec rake heroku:app:restart_dyno[web]
+      desc "Restart a dyno."
+      task :restart_dyno, [:dyno_name] => :environment do |t, args|
+
+        # Note: get the HEROKU_OAUTH_TOKEN using:
+        #   heroku authorizations:create -d "Portal Admin API token" 
+        heroku = PlatformAPI.connect_oauth(ENV['HEROKU_OAUTH_TOKEN'])
+
+        # Note: HEROKU_APP_NAME is supposed to be availble on a normal dyno (in addition to Review Apps) after running:
+        #   heroku labs:enable runtime-dyno-metadata
+        # but it didn't seem to be so I set it manually
+        heroku.dyno.restart(ENV['HEROKU_APP_NAME'], args[:dyno_name])
+
+      end
+
+  end # Namespace: app
+
+end # Namespace: heroku
+


### PR DESCRIPTION
This is intended to be used from the Scheduler add-on
(or some other add-on) to restart the dyno in the middle of
the night daily so that we're not at the whims of the dyno
manager cycling it.

TESTING:

After creating an oauth token using
heroku authorizations:create -d "Join Admin API token" -s write
I ran:
HEROKU_OAUTH_TOKEN=my-token HEROKU_APP_NAME=my-app bundle exec rake heroku:app:restart_dyno[web]
and verified that the dyno restarted