### PR TITLE
Update dev env to use new platform hosted SSO server.

### DIFF
--- a/docker-compose/.env-docker
+++ b/docker-compose/.env-docker
@@ -32,7 +32,7 @@ CANVAS_PORT=3000
 CANVAS_USE_SSL=false
 CANVAS_ALLOW_SELF_SIGNED_SSL=true
 
-SSO_URL=http://ssoweb:3002/
+SSO_URL=http://platformweb:3020/cas/
 
 # This is used to register the webhook with calend.ly so it can call in when volunteers
 # signup for or cancel their commitment to volunteer at a Braven event.


### PR DESCRIPTION
TESTING:
- Rebuilt the docker-compose containers and verified
  that logging into http://joinweb/admin uses http://platformweb
  as the SSO server