### PR TITLE
Make delayed jobs config more sane

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,0 +1,5 @@
+Delayed::Worker.sleep_delay = 10
+Delayed::Worker.max_attempts = 2
+Delayed::Worker.max_run_time = 10.minutes
+Delayed::Worker.delay_jobs = !Rails.env.test?
+Delayed::Worker.raise_signal_exceptions = :term


### PR DESCRIPTION
Failed jobs were retrying up to 25 times. We ran into this crazy situation
where we tried to upload the event dates to the Portal with the "Delete existing events"
option checked off. We had some non-ASCII characters in the sheet uploaded which caused
the job to fail on the 3rd event when calling into the Portal API. Then, the failed
job continued running for days and kept overwriting the event dates for the
first two and deleting the rest. Now, just retry a failed job one time and then give up
by default. You can still override this for individual jobs if you want.

I also made some of the other settings more sane than the defaults.

TESTING:
- Hacked the app/controllers/admin/events_controller.rb to call
  lms.delay.commit_new_events(...) with a nil "changed" param so that
  it would fail. In the console, ran:
    worker = Delayed::Worker.new({quiet: false})
    worker.start
  and saw that it gave up after 2 tries
    2020-02-10T14:08:32+0000: [Worker(host:53352b76d441 pid:42)] Job BeyondZ::LMS#commit_new_events (id=980) REMOVED permanently because of 2 consecutive failures