### PR TITLE
redirect Fellow signup page to ENV variable

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -426,6 +426,15 @@ class UsersController < ApplicationController
 
     load_special_program
 
+    # no longer allow signing up as a Fellow through the Join server
+    applicant_type = params[:user] && params[:user][:applicant_type]
+    allow_redirect = ENV['ALLOW_FELLOW_SIGNUP_REDIRECT'] == "true"
+
+    if allow_redirect && applicant_type == 'undergrad_student'
+      return redirect_to ENV['FORMASSEMBLY_FELLOW_SIGNUP_URL']
+    end
+
+
     if params[:user]
       @user.applicant_type = params[:user][:applicant_type] if params[:user][:applicant_type]
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -428,12 +428,14 @@ class UsersController < ApplicationController
 
     # no longer allow signing up as a Fellow through the Join server
     applicant_type = params[:user] && params[:user][:applicant_type]
-    allow_redirect = ENV['ALLOW_FELLOW_SIGNUP_REDIRECT'] == "true"
 
-    if allow_redirect && applicant_type == 'undergrad_student'
-      return redirect_to ENV['FORMASSEMBLY_FELLOW_SIGNUP_URL']
+    if applicant_type == 'undergrad_student'
+      fellow_redirect_url = ENV['FORMASSEMBLY_FELLOW_SIGNUP_URL']
+      return redirect_to fellow_redirect_url unless fellow_redirect_url.blank?
+    elsif applicant_type == 'leadership_coach'
+      lc_redirect_URL = ENV['FORMASSEMBLY_LC_SIGNUP_URL']
+      return redirect_to lc_redirect_URL unless lc_redirect_URL.blank?
     end
-
 
     if params[:user]
       @user.applicant_type = params[:user][:applicant_type] if params[:user][:applicant_type]

--- a/docker-compose/.env-docker
+++ b/docker-compose/.env-docker
@@ -104,4 +104,4 @@ QA_TOKEN=blahblahblahalskdfjalskfj
 
 # These variables control whether the signup flow gets redirected to another URL
 FORMASSEMBLY_FELLOW_SIGNUP_URL=https://www.google.com/?q=put+form+assembly+url+here&oq=put+form+assembly+url+here
-ALLOW_FELLOW_SIGNUP_REDIRECT=true
+FORMASSEMBLY_LC_SIGNUP_URL=https://www.google.com/?q=put+form+assembly+url+here&oq=put+form+assembly+url+here

--- a/docker-compose/.env-docker
+++ b/docker-compose/.env-docker
@@ -101,3 +101,7 @@ QA_HOST=helpweb:3006
 # TODO: tmp for testing.  we don't have a staging version, so unset this when testing is over to prevent
 # staging from posting to the real site.
 QA_TOKEN=blahblahblahalskdfjalskfj
+
+# These variables control whether the signup flow gets redirected to another URL
+FORMASSEMBLY_FELLOW_SIGNUP_URL=https://www.google.com/?q=put+form+assembly+url+here&oq=put+form+assembly+url+here
+ALLOW_FELLOW_SIGNUP_REDIRECT=true


### PR DESCRIPTION
This PR has the Fellow signup page redirect to a page of our choosing via an ENV var. The functionality can also be turned on or off based on a different ENV var.

Test Plan: Clicked on "As a Fellow (Student)" from here locally: http://joinweb:3001/signup/new. Also checked that env var turns it off