### PR TITLE
Force traffic over SSL.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,11 +46,8 @@ BeyondzPlatform::Application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
-  # See this post for a way to setup the DNS to work with the root domain: 
-  #    http://stackoverflow.com/questions/6701549/heroku-ssl-on-root-domain
-  # Unfortunately, I couldn't get it to work after trying a few variations.  So I'm reverting to default behavior.
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  #config.force_ssl = true
+  config.force_ssl = true
 
   # Set to :debug to see everything in the log.
   config.log_level = :info


### PR DESCRIPTION
For staging, I followed these steps to upload our SSL cert manually (since the newer
LetsEncrypt certs weren't working with some of our code), switched the DNS
over to point at this app, and see that the cert being used is the one I uploaded.
Now disable plain http access.

https://devcenter.heroku.com/articles/ssl#manually-uploading-certificates-and-intermediaries

Test Plan:
- Log in to the admin dashboard at stagingjoin.bebraven.org/admin and use Create Special Canvas User.
- Log in and log out of stagingportal.bebraven.org using the user I just created.
- Log directly into stagingkits.bebraven.org (in an incognito window).
- Run the following to try and push attendance changes from kits to canvas (on the staging kits server):
   cd /var/www/html; php /var/www/html/attendance_api.php 2>&1 >> /var/www/html/log/attendance_api_cron.log

If everything looks good, do this for production too and then deploy this commit.
In production, also test that the portaleditor can push changes.