### PR TITLE
Allow another option for Fellow/LC redirect signup

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -427,7 +427,8 @@ class UsersController < ApplicationController
     load_special_program
 
     # no longer allow signing up as a Fellow through the Join server
-    applicant_type = params[:user] && params[:user][:applicant_type]
+    applicant_type = (params[:applicant_type] || 
+      (params[:user] && params[:user][:applicant_type]))
 
     if applicant_type == 'undergrad_student'
       fellow_redirect_url = ENV['FORMASSEMBLY_FELLOW_SIGNUP_URL']


### PR DESCRIPTION
This PR just lets the redirect work even if the applicant_type isn't embedded within a user param.

Test Plan: made sure it redirects when applicant_type is top-level and also nested