### PR TITLE
Handle mentor application for folks with existing accounts.

### DIFF
--- a/app/controllers/mentor_controller.rb
+++ b/app/controllers/mentor_controller.rb
@@ -182,6 +182,10 @@ class MentorController < ApplicationController
     # This is hacky, but we create the application with some prepopulated fields on the new user form. Start from that.
     # Things like functional_area are already set on it.
     application = MentorApplication.where("user_id = #{current_user.id}").first
+    unless application
+      application = MentorApplication.new(:user_id => current_user.id, :employer => current_user.company, :phone => current_user.phone, :title => current_user.profession)
+      Rails.logger.warn "MentorApplication not found for #{current_user}. It was supposed to be created on the profile page. Creating a blank one. Probably means this was an existing user."
+    end
 
     application.application_type = 'mentor'
     application.campaign_id = params[:campaign_id]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -571,6 +571,7 @@ class UsersController < ApplicationController
       @hide_other_applicant_types = true
       @user = @new_user
       load_special_program
+      set_up_lists
       render 'new'
       return
     end


### PR DESCRIPTION
For example, a former LC may login and get the mentor application
by-passing the profile / sign-up page.