### PR TITLE
Add limit to how_hear input

### DIFF
--- a/app/views/mentor/mentee_app.html.erb
+++ b/app/views/mentor/mentee_app.html.erb
@@ -215,7 +215,7 @@
             <br />
             <b>How did you hear about this opportunity?</b>
             <label>
-              <input class="form-control" name="how_hear" type="text" />
+              <input class="form-control" name="how_hear" type="text" maxlength="255" />
             </label>
             <br />
             <b>Do you have any lingering questions about the Braven Professional Mentor Program?</b>


### PR DESCRIPTION
The [how_hear](https://github.com/beyond-z/beyondz-platform/blob/staging/db/schema.rb#L396) input is a `t.string` with a limit of 255. Without the limit, a user can enter say 309 characters and it'll error out.

- Set maxlength to 255 for how_hear input