### PR TITLE
Allow both bebraven.org and braven.org to iframe stuff.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     # These take precedence over any values in the above file.
     # Set them in your shell before using docker-compose so they get passed in.
     environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       DATABASEDOTCOM_CLIENT_ID: ${DATABASEDOTCOM_CLIENT_ID}
       DATABASEDOTCOM_CLIENT_SECRET: ${DATABASEDOTCOM_CLIENT_SECRET}
       SALESFORCE_USERNAME: ${SALESFORCE_USERNAME}

--- a/docker-compose/.env-docker
+++ b/docker-compose/.env-docker
@@ -12,6 +12,10 @@ DATABASE_NAME=joindb
 DATABASE_USER=postgres
 DATABASE_PASSWORD=
 
+# Note: the AWS access key and secret must be set in your shell env if you
+# want things that need the bucket to work, like the resume and cover letter bank.
+AWS_BUCKET=beyondz-dev-assets
+
 SMTP_SERVER=yoursmptserver
 SMTP_USERNAME=fakesmtpusername
 SMTP_PASSWORD=fakesmtppassword


### PR DESCRIPTION
We have a resume and cover letter bank in the portal that iframe's
a page here on the Join server. We have two portals, one hosted at
booster.braven.org and one at portal.bebraven.org that need to be
able to iframe the resume/cover letter page. Also, soon we will be
migrating portal.bebraven.org to portal.braven.org. This commit
allows those iframes to work.

See: https://app.asana.com/0/1170770467635599/1173810330734585

### Test Plan:
- Load these two pages in prodution and make sure the iframe works:
  https://portal.bebraven.org/courses/1/pages/resume-and-cover-letter-bank
  https://booster.braven.org/courses/1/pages/resume-and-cover-letter-bank
- Make sure it also works in the dev env.
- If you get really ambitious try to iframe it on other domains in production
  and see that it doesn't work.
- If you get really, really ambitious try it out on older browsers and see what happens.