### PR TITLE
Patch up Braven Network/connect

### DIFF
--- a/app/views/champions/openid_auth.html.erb
+++ b/app/views/champions/openid_auth.html.erb
@@ -1,14 +1,3 @@
-<p>Logging you into the Braven Network....</p>
-<script src="//<%= Rails.application.secrets.canvas_server %>/openid/url_script"></script>
-<script>
-  if(bz_current_user_openid_url === null) {
-    // the fellow isn't logged into Canvas, send them back to the LMS to log in via
-    // its SSO (which may be Braven login or a university partner)
-    //window.location.href = "/connect_authenticated";
-    window.location.href = "//<%= Rails.application.secrets.canvas_server %>";
-  } else {
-    // they ARE logged into Canvas, use that OpenID url to log them into the Join
-    // server
-    window.location.href = "/champions/openid_login_start?url=" + encodeURIComponent(bz_current_user_openid_url);
-  }
-</script>
+<p>
+  To finish logging into the Braven Network, click <a href="/users/sign_in_sso">here</a>....
+</p>


### PR DESCRIPTION
https://app.asana.com/0/1109150244034467/1199910849205333

The code for logging into Braven Network looks horrifically broken and complicated. There's errors related to hitting Canvas for an openid/url_script, which breaks the Braven Network Connect page and also generates lots of errors on the Canvas side. I haven't teased apart how the SSO works, but it does seem that clicking on Log In in the top right works. This pull request just cuts out the call to Canvas and also makes it more obvious that users should click on the link to login from platform.

Test Plan: Well, I may have pushed it to production to test and then quickly reverted.... I did this because our dev environment to login to the Braven Network is broken.